### PR TITLE
Create SQRAbstractProcessor, which extends spoon.processing.AbstractProcessor

### DIFF
--- a/src/main/java/sonarquberepair/processor/SQRAbstractProcessor.java
+++ b/src/main/java/sonarquberepair/processor/SQRAbstractProcessor.java
@@ -1,0 +1,14 @@
+package sonarquberepair.processor;
+
+import sonarquberepair.UniqueTypesCollector;
+import spoon.processing.AbstractProcessor;
+import spoon.reflect.declaration.CtElement;
+
+public abstract class SQRAbstractProcessor<E extends CtElement> extends AbstractProcessor<E> {
+
+	@Override
+	public void process(E element) {
+		UniqueTypesCollector.getInstance().collect(element);
+	}
+
+}

--- a/src/main/java/sonarquberepair/processor/SQRAbstractProcessor.java
+++ b/src/main/java/sonarquberepair/processor/SQRAbstractProcessor.java
@@ -4,6 +4,7 @@ import sonarquberepair.UniqueTypesCollector;
 import spoon.processing.AbstractProcessor;
 import spoon.reflect.declaration.CtElement;
 
+/** superclass for all processors */
 public abstract class SQRAbstractProcessor<E extends CtElement> extends AbstractProcessor<E> {
 
 	@Override

--- a/src/main/java/sonarquberepair/processor/sonarbased/DeadStoreProcessor.java
+++ b/src/main/java/sonarquberepair/processor/sonarbased/DeadStoreProcessor.java
@@ -4,8 +4,6 @@ import spoon.reflect.code.CtAssignment;
 import spoon.reflect.code.CtLocalVariable;
 import spoon.reflect.code.CtStatement;
 
-import sonarquberepair.UniqueTypesCollector;
-
 public class DeadStoreProcessor extends SonarWebAPIBasedProcessor<CtStatement> {
 
 	public DeadStoreProcessor(String projectKey) {
@@ -25,7 +23,7 @@ public class DeadStoreProcessor extends SonarWebAPIBasedProcessor<CtStatement> {
 
 	@Override
 	public void process(CtStatement element) {
-		UniqueTypesCollector.getInstance().collect(element);
+		super.process(element);
 		element.delete();
 	}
 

--- a/src/main/java/sonarquberepair/processor/sonarbased/SerializableFieldInSerializableClassProcessor.java
+++ b/src/main/java/sonarquberepair/processor/sonarbased/SerializableFieldInSerializableClassProcessor.java
@@ -3,9 +3,6 @@ package sonarquberepair.processor.sonarbased;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.ModifierKind;
 
-import sonarquberepair.UniqueTypesCollector;
-
-
 public class SerializableFieldInSerializableClassProcessor extends SonarWebAPIBasedProcessor<CtField> {
 
 	public SerializableFieldInSerializableClassProcessor(String projectKey) {
@@ -22,7 +19,7 @@ public class SerializableFieldInSerializableClassProcessor extends SonarWebAPIBa
 
 	@Override
 	public void process(CtField element) {
-		UniqueTypesCollector.getInstance().collect(element);
+		super.process(element);
 		element.addModifier(ModifierKind.TRANSIENT);
 	}
 

--- a/src/main/java/sonarquberepair/processor/sonarbased/SonarWebAPIBasedProcessor.java
+++ b/src/main/java/sonarquberepair/processor/sonarbased/SonarWebAPIBasedProcessor.java
@@ -8,10 +8,10 @@ import java.util.Set;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
-import spoon.processing.AbstractProcessor;
+import sonarquberepair.processor.SQRAbstractProcessor;
 import spoon.reflect.declaration.CtElement;
 
-public abstract class SonarWebAPIBasedProcessor<E extends CtElement> extends AbstractProcessor<E> {
+public abstract class SonarWebAPIBasedProcessor<E extends CtElement> extends SQRAbstractProcessor<E> {
 
 	private JSONArray jsonArray; //array of JSONObjects, each of which is a bug
 	private Set<Bug> setOfBugs; //set of bugs, corresponding to jsonArray

--- a/src/main/java/sonarquberepair/processor/sonarbased/UnclosedResourcesProcessor.java
+++ b/src/main/java/sonarquberepair/processor/sonarbased/UnclosedResourcesProcessor.java
@@ -13,8 +13,6 @@ import spoon.reflect.declaration.CtElement;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtVariableReference;
 
-import sonarquberepair.UniqueTypesCollector;
-
 public class UnclosedResourcesProcessor extends SonarWebAPIBasedProcessor<CtConstructorCall> {
 
 	public UnclosedResourcesProcessor(String projectKey) {
@@ -35,7 +33,7 @@ public class UnclosedResourcesProcessor extends SonarWebAPIBasedProcessor<CtCons
 
 	@Override
 	public void process(CtConstructorCall element) {
-		UniqueTypesCollector.getInstance().collect(element);
+		super.process(element);
 
 		CtElement parent = element.getParent(e -> e instanceof CtAssignment || e instanceof CtLocalVariable);
 

--- a/src/main/java/sonarquberepair/processor/spoonbased/ArrayHashCodeAndToStringProcessor.java
+++ b/src/main/java/sonarquberepair/processor/spoonbased/ArrayHashCodeAndToStringProcessor.java
@@ -1,6 +1,6 @@
 package sonarquberepair.processor.spoonbased;
 
-import spoon.processing.AbstractProcessor;
+import sonarquberepair.processor.SQRAbstractProcessor;
 import spoon.reflect.code.CtCodeSnippetExpression;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtInvocation;
@@ -10,9 +10,7 @@ import spoon.reflect.reference.CtExecutableReference;
 
 import java.util.Arrays;
 
-import sonarquberepair.UniqueTypesCollector;
-
-public class ArrayHashCodeAndToStringProcessor extends AbstractProcessor<CtInvocation<?>> {
+public class ArrayHashCodeAndToStringProcessor extends SQRAbstractProcessor<CtInvocation<?>> {
 
 	final String TOSTRING = "toString";
 	final String HASHCODE = "hashCode";
@@ -34,7 +32,7 @@ public class ArrayHashCodeAndToStringProcessor extends AbstractProcessor<CtInvoc
 
 	@Override
 	public void process(CtInvocation<?> element) {
-		UniqueTypesCollector.getInstance().collect(element);
+		super.process(element);
 
 		CtExpression prevTarget = element.getTarget();
 		CtCodeSnippetExpression newTarget = getFactory().Code().createCodeSnippetExpression("Arrays");

--- a/src/main/java/sonarquberepair/processor/spoonbased/BigDecimalDoubleConstructorProcessor.java
+++ b/src/main/java/sonarquberepair/processor/spoonbased/BigDecimalDoubleConstructorProcessor.java
@@ -1,7 +1,6 @@
 package sonarquberepair.processor.spoonbased;
 
-import sonarquberepair.UniqueTypesCollector;
-import spoon.processing.AbstractProcessor;
+import sonarquberepair.processor.SQRAbstractProcessor;
 import spoon.reflect.code.*;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
@@ -11,7 +10,7 @@ import spoon.reflect.reference.CtTypeReference;
 import java.math.BigDecimal;
 import java.util.List;
 
-public class BigDecimalDoubleConstructorProcessor extends AbstractProcessor<CtConstructorCall> {
+public class BigDecimalDoubleConstructorProcessor extends SQRAbstractProcessor<CtConstructorCall> {
 
 	@Override
 	public boolean isToBeProcessed(CtConstructorCall cons) {
@@ -31,7 +30,7 @@ public class BigDecimalDoubleConstructorProcessor extends AbstractProcessor<CtCo
 
 	@Override
 	public void process(CtConstructorCall cons) {
-		UniqueTypesCollector.getInstance().collect(cons);
+		super.process(cons);
 
 		if (cons.getArguments().size() == 1) {
 			CtType bigDecimalClass = getFactory().Class().get(BigDecimal.class);

--- a/src/main/java/sonarquberepair/processor/spoonbased/CastArithmeticOperandProcessor.java
+++ b/src/main/java/sonarquberepair/processor/spoonbased/CastArithmeticOperandProcessor.java
@@ -1,6 +1,6 @@
 package sonarquberepair.processor.spoonbased;
 
-import spoon.processing.AbstractProcessor;
+import sonarquberepair.processor.SQRAbstractProcessor;
 import spoon.reflect.code.*;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtField;
@@ -11,9 +11,7 @@ import spoon.reflect.visitor.filter.TypeFilter;
 
 import java.util.List;
 
-import sonarquberepair.UniqueTypesCollector;
-
-public class CastArithmeticOperandProcessor extends AbstractProcessor<CtBinaryOperator> {
+public class CastArithmeticOperandProcessor extends SQRAbstractProcessor<CtBinaryOperator> {
 
     private CtTypeReference typeToBeUsedToCast;
 
@@ -39,7 +37,7 @@ public class CastArithmeticOperandProcessor extends AbstractProcessor<CtBinaryOp
 
     @Override
     public void process(CtBinaryOperator element) {
-        UniqueTypesCollector.getInstance().collect(element);
+        super.process(element);
 
         CtCodeSnippetExpression newBinaryOperator = element.getFactory().createCodeSnippetExpression("(" + typeToBeUsedToCast.getSimpleName() + ") " + element.getLeftHandOperand());
         element.setLeftHandOperand(newBinaryOperator);

--- a/src/main/java/sonarquberepair/processor/spoonbased/CompareStringsBoxedTypesWithEqualsProcessor.java
+++ b/src/main/java/sonarquberepair/processor/spoonbased/CompareStringsBoxedTypesWithEqualsProcessor.java
@@ -1,6 +1,6 @@
 package sonarquberepair.processor.spoonbased;
 
-import spoon.processing.AbstractProcessor;
+import sonarquberepair.processor.SQRAbstractProcessor;
 import spoon.reflect.code.CtCodeSnippetExpression;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.declaration.CtElement;
@@ -8,9 +8,7 @@ import spoon.reflect.code.BinaryOperatorKind;
 import spoon.reflect.code.CtBinaryOperator;
 import spoon.reflect.reference.CtTypeReference;
 
-import sonarquberepair.UniqueTypesCollector;
-
-public class CompareStringsBoxedTypesWithEqualsProcessor extends AbstractProcessor<CtElement> {
+public class CompareStringsBoxedTypesWithEqualsProcessor extends SQRAbstractProcessor<CtElement> {
 
 	@Override
 	public boolean isToBeProcessed(CtElement candidate) {
@@ -51,7 +49,7 @@ public class CompareStringsBoxedTypesWithEqualsProcessor extends AbstractProcess
 
 	@Override
 	public void process(CtElement element) {
-		UniqueTypesCollector.getInstance().collect(element);
+		super.process(element);
 
 		CtBinaryOperator bo = (CtBinaryOperator) element;
 		String negation = "";

--- a/src/main/java/sonarquberepair/processor/spoonbased/IteratorNextExceptionProcessor.java
+++ b/src/main/java/sonarquberepair/processor/spoonbased/IteratorNextExceptionProcessor.java
@@ -1,6 +1,6 @@
 package sonarquberepair.processor.spoonbased;
 
-import spoon.processing.AbstractProcessor;
+import sonarquberepair.processor.SQRAbstractProcessor;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtCodeSnippetExpression;
 import spoon.reflect.code.CtExpression;
@@ -14,9 +14,7 @@ import spoon.reflect.reference.CtTypeReference;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
-import sonarquberepair.UniqueTypesCollector;
-
-public class IteratorNextExceptionProcessor extends AbstractProcessor<CtMethod> {
+public class IteratorNextExceptionProcessor extends SQRAbstractProcessor<CtMethod> {
 
 	/**
 	 * @param candidate - Every method of the scanned file
@@ -50,7 +48,7 @@ public class IteratorNextExceptionProcessor extends AbstractProcessor<CtMethod> 
 
 	@Override
 	public void process(CtMethod method) {
-		UniqueTypesCollector.getInstance().collect(method);
+		super.process(method);
 
 		CtIf anIf = getFactory().Core().createIf();
 		CtCodeSnippetExpression expr = getFactory().Core().createCodeSnippetExpression();


### PR DESCRIPTION
This PR adds `SQRAbstractProcessor` (SQR = SonarQube-Repair), which extends `spoon.processing.AbstractProcessor`. The motivation for that is that our processors were extending `spoon.processing.AbstractProcessor` directly, without a single, unified super class on sonarqube-repair side for all processors. In this way now, the project is more organized and most important, the same behavior that should be applied to all processors can be implemented only in the super class `SQRAbstractProcessor`, which is the case of the new feature that @henry-lp recently added where the storage of the element being processed is required.