### PR TITLE
Add MathOnFloatProcessor (SonarSource rule 2164)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Sonarqube-repair is a collection of java code analyses and transformations made with the [Spoon](https://github.com/INRIA/spoon) library to repair violations of rules contained in [SonarQube](https://rules.sonarsource.com).
 
 ## Handled rules
-Sonarqube-repair can currently repair violations of 10 rules of which 8 are labeled as `BUG` and 2 as `Code Smell`. [Check out the handled rules](/docs/HANDLED_RULES.md).
+Sonarqube-repair can currently repair violations of 11 rules of which 9 are labeled as `BUG` and 2 as `Code Smell`. [Check out the handled rules](/docs/HANDLED_RULES.md).
 
 ## Getting started
 

--- a/docs/HANDLED_RULES.md
+++ b/docs/HANDLED_RULES.md
@@ -1,5 +1,5 @@
 ## Handled rules
-Sonarqube-repair can currently repair violations of 10 rules of which 8 are labeled as `BUG` and 2 as `Code Smell`:
+Sonarqube-repair can currently repair violations of 11 rules of which 9 are labeled as `BUG` and 2 as `Code Smell`:
 
 * [Bug](#bug)
     * [Resources should be closed](#resources-should-be-closed-sonar-rule-2095) ([Sonar Rule 2095](https://rules.sonarsource.com/java/RSPEC-2095))
@@ -10,6 +10,7 @@ Sonarqube-repair can currently repair violations of 10 rules of which 8 are labe
     * [Math operands should be cast before assignment](#math-operands-should-be-cast-before-assignment-sonar-rule-2184) ([Sonar Rule 2184](https://rules.sonarsource.com/java/RSPEC-2184))
     * [JEE applications should not "getClassLoader"](#jee-applications-should-not-getclassloader-sonar-rule-3032) ([Sonar Rule 3032](https://rules.sonarsource.com/java/RSPEC-3032))
     * ["compareTo" should not return "Integer.MIN_VALUE"](#compareto-should-not-return-integermin_value-sonar-rule-2167) ([Sonar Rule 2167](https://rules.sonarsource.com/java/RSPEC-2167))
+    * [Math should not be performed on floats](#math-should-not-be-performed-on-floats-sonar-rule-2164) ([Sonar Rule 2164](https://rules.sonarsource.com/java/RSPEC-2164))
 * [Code Smell](#code-smell)
     * [Unused assignments should be removed](#unused-assignments-should-be-removed-sonar-rule-1854) ([Sonar Rule 1854](https://rules.sonarsource.com/java/RSPEC-1854))
     * [Fields in a "Serializable" class should either be transient or serializable](#fields-in-a-serializable-class-should-either-be-transient-or-serializable-sonar-rule-1948) ([Sonar Rule 1948](https://rules.sonarsource.com/java/RSPEC-1948))
@@ -166,6 +167,20 @@ Returning `Integer.MIN_VALUE` can cause errors because the return value of `comp
 +  public int compareTo(CompareToReturnValue a) {
 +     return -1;
 +  }
+```
+
+-----
+
+#### Math should not be performed on floats ([Sonar Rule 2164](https://rules.sonarsource.com/java/RSPEC-2164))
+
+In arithmetic expressions between two `float`s, both left and right operands are casted to `double`.
+
+Example:
+```diff
+         float a = 16777216.0f;
+         float b = 1.0f;
+-        float c = a + b; // Noncompliant, yields 1.6777216E7 not 1.6777217E7
++        float c = (double) a + (double) b;
 ```
 
 -----

--- a/src/main/java/sonarquberepair/Processors.java
+++ b/src/main/java/sonarquberepair/Processors.java
@@ -10,6 +10,7 @@ import sonarquberepair.processor.spoonbased.CompareStringsBoxedTypesWithEqualsPr
 import sonarquberepair.processor.spoonbased.IteratorNextExceptionProcessor;
 import sonarquberepair.processor.spoonbased.GetClassLoaderProcessor;
 import sonarquberepair.processor.spoonbased.CompareToReturnValueProcessor;
+import sonarquberepair.processor.spoonbased.MathOnFloatProcessor;
 
 import spoon.processing.Processor;
 
@@ -34,6 +35,7 @@ public class Processors {
 		TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(2184, CastArithmeticOperandProcessor.class);
 		TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(3032, GetClassLoaderProcessor.class);
 		TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(2167, CompareToReturnValueProcessor.class);
+		TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(2164, MathOnFloatProcessor.class);
 		return TEMP_RULE_KEY_TO_PROCESSOR;
 	}
 

--- a/src/main/java/sonarquberepair/processor/spoonbased/MathOnFloatProcessor.java
+++ b/src/main/java/sonarquberepair/processor/spoonbased/MathOnFloatProcessor.java
@@ -1,0 +1,57 @@
+package sonarquberepair.processor.spoonbased;
+
+import sonarquberepair.processor.SQRAbstractProcessor;
+import spoon.reflect.code.BinaryOperatorKind;
+import spoon.reflect.code.CtBinaryOperator;
+import spoon.reflect.code.CtCodeSnippetExpression;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.visitor.filter.TypeFilter;
+
+import java.util.List;
+
+public class MathOnFloatProcessor extends SQRAbstractProcessor<CtBinaryOperator> {
+
+    @Override
+    public boolean isToBeProcessed(CtBinaryOperator candidate) {
+        List<CtBinaryOperator> binaryOperatorChildren = candidate.getElements(new TypeFilter<>(CtBinaryOperator.class));
+        if (binaryOperatorChildren.size() == 1) { // in a nested binary operator expression, only one will be processed.
+            if (isArithmeticOperation(candidate) && isOperationBetweenFloats(candidate) && !withinStringConcatenation(candidate)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void process(CtBinaryOperator element) {
+        super.process(element);
+
+        CtCodeSnippetExpression newLeftHandOperand = element.getFactory().createCodeSnippetExpression("(double) " + element.getLeftHandOperand());
+        element.setLeftHandOperand(newLeftHandOperand);
+        CtCodeSnippetExpression newRightHandOperand = element.getFactory().createCodeSnippetExpression("(double) " + element.getRightHandOperand());
+        element.setRightHandOperand(newRightHandOperand);
+    }
+
+    private boolean isArithmeticOperation(CtBinaryOperator ctBinaryOperator) {
+        return ctBinaryOperator.getKind().compareTo(BinaryOperatorKind.PLUS) == 0 ||
+                ctBinaryOperator.getKind().compareTo(BinaryOperatorKind.MINUS) == 0 ||
+                ctBinaryOperator.getKind().compareTo(BinaryOperatorKind.MUL) == 0 ||
+                ctBinaryOperator.getKind().compareTo(BinaryOperatorKind.DIV) == 0;
+    }
+
+    private boolean isOperationBetweenFloats(CtBinaryOperator ctBinaryOperator) {
+        return ctBinaryOperator.getLeftHandOperand().getType().getSimpleName().equals("float") &&
+                ctBinaryOperator.getRightHandOperand().getType().getSimpleName().equals("float");
+    }
+
+    private boolean withinStringConcatenation(CtBinaryOperator ctBinaryOperator) {
+        CtElement parent = ctBinaryOperator;
+        while (parent.getParent() instanceof CtBinaryOperator) {
+            parent = parent.getParent();
+        }
+        return ((CtBinaryOperator) parent).getKind().compareTo(BinaryOperatorKind.PLUS) == 0 &&
+                (((CtBinaryOperator) parent).getLeftHandOperand().getType().getQualifiedName().equals("java.lang.String") ||
+                        ((CtBinaryOperator) parent).getRightHandOperand().getType().getQualifiedName().equals("java.lang.String"));
+    }
+
+}

--- a/src/test/java/sonarquberepair/processor/spoonbased/MathOnFloatProcessorTest.java
+++ b/src/test/java/sonarquberepair/processor/spoonbased/MathOnFloatProcessorTest.java
@@ -1,0 +1,29 @@
+package sonarquberepair.processor.spoonbased;
+
+import org.junit.Test;
+import org.sonar.java.checks.MathOnFloatCheck;
+import org.sonar.java.checks.verifier.JavaCheckVerifier;
+import sonarquberepair.Constants;
+import sonarquberepair.Main;
+import sonarquberepair.TestHelper;
+
+public class MathOnFloatProcessorTest {
+
+    @Test
+    public void test() throws Exception {
+        String fileName = "MathOnFloat.java";
+        String pathToBuggyFile = Constants.PATH_TO_FILE + fileName;
+        String pathToRepairedFile = Constants.WORKSPACE + "/spooned/" + fileName;
+
+        JavaCheckVerifier.verify(pathToBuggyFile, new MathOnFloatCheck());
+        Main.main(new String[]{
+                "--originalFilesPath",pathToBuggyFile,
+                "--projectKey", Constants.PROJECT_KEY,
+                "--ruleKeys","2164",
+                "--prettyPrintingStrategy","SNIPER",
+                "--workspace",Constants.WORKSPACE});
+        TestHelper.removeComplianceComments(pathToRepairedFile);
+        JavaCheckVerifier.verifyNoIssue(pathToRepairedFile, new MathOnFloatCheck());
+    }
+
+}

--- a/src/test/resources/MathOnFloat.java
+++ b/src/test/resources/MathOnFloat.java
@@ -1,0 +1,27 @@
+// Test for rule s2164
+
+class MathOnFloat {
+
+    // Tests from https://github.com/SonarSource/sonar-java/blob/master/java-checks-test-sources/src/main/java/checks/MathOnFloatCheck.java
+    void myMethod() {
+        float a = 16777216.0f;
+        float b = 1.0f;
+        float c = a + b; // Noncompliant {{Use a "double" or "BigDecimal" instead.}} yields 1.6777216E7 not 1.6777217E7
+
+        double d1 = a + b; // Noncompliant ; addition is still between 2 floats
+        double d2 = a - b; // Noncompliant
+        double d3 = a * b; // Noncompliant
+        double d4 = a / b; // Noncompliant
+        double d5 = a / b + b; // Noncompliant, only one issue should be reported
+
+        double d6 = a + d1;
+
+        int i = 16777216;
+        int j = 1;
+        int k = i + j;
+        System.out.println("[Max time to retrieve connection:"+(a/1000f/1000f)+" ms.");
+        System.out.println("[Max time to retrieve connection:"+a/1000f/1000f);
+        float foo = 12 + a/1000f/1000f; // Noncompliant
+    }
+
+}


### PR DESCRIPTION
This PR adds a processor for the rule [Math should not be performed on floats](https://rules.sonarsource.com/java/type/Bug/RSPEC-2164).

Transformation:

```diff
 // Test for rule s2164
 
 class MathOnFloat {
 
     // Tests from https://github.com/SonarSource/sonar-java/blob/master/java-checks-test-sources/src/main/java/checks/MathOnFloatCheck.java
     void myMethod() {
         float a = 16777216.0f;
         float b = 1.0f;
-        float c = a + b; // Noncompliant {{Use a "double" or "BigDecimal" instead.}} yields 1.6777216E7 not 1.6777217E7
+        float c = (double) a + (double) b; 
 
-        double d1 = a + b; // Noncompliant ; addition is still between 2 floats
-        double d2 = a - b; // Noncompliant
-        double d3 = a * b; // Noncompliant
-        double d4 = a / b; // Noncompliant
-        double d5 = a / b + b; // Noncompliant, only one issue should be reported
+        double d1 = (double) a + (double) b; 
+        double d2 = (double) a - (double) b; 
+        double d3 = (double) a * (double) b; 
+        double d4 = (double) a / (double) b; 
+        double d5 = ((double) a / (double) b) + b; 
 
         double d6 = a + d1;
 
         int i = 16777216;
         int j = 1;
         int k = i + j;
         System.out.println("[Max time to retrieve connection:"+(a/1000f/1000f)+" ms.");
         System.out.println("[Max time to retrieve connection:"+a/1000f/1000f);
-        float foo = 12 + a/1000f/1000f; // Noncompliant
+        float foo = 12 + (((double) a/(double) 1000.0F)/1000f); 
     }
 
 }
```