### PR TITLE
Add EqualsOnAtomicClassProcessor (SonarSource rule 2204)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Sonarqube-repair is a collection of java code analyses and transformations made with the [Spoon](https://github.com/INRIA/spoon) library to repair violations of rules contained in [SonarQube](https://rules.sonarsource.com).
 
 ## Handled rules
-Sonarqube-repair can currently repair violations of 11 rules of which 9 are labeled as `BUG` and 2 as `Code Smell`. [Check out the handled rules](/docs/HANDLED_RULES.md).
+Sonarqube-repair can currently repair violations of 12 rules of which 10 are labeled as `BUG` and 2 as `Code Smell`. [Check out the handled rules](/docs/HANDLED_RULES.md).
 
 ## Getting started
 

--- a/docs/HANDLED_RULES.md
+++ b/docs/HANDLED_RULES.md
@@ -1,5 +1,5 @@
 ## Handled rules
-Sonarqube-repair can currently repair violations of 11 rules of which 9 are labeled as `BUG` and 2 as `Code Smell`:
+Sonarqube-repair can currently repair violations of 12 rules of which 10 are labeled as `BUG` and 2 as `Code Smell`:
 
 * [Bug](#bug)
     * [Resources should be closed](#resources-should-be-closed-sonar-rule-2095) ([Sonar Rule 2095](https://rules.sonarsource.com/java/RSPEC-2095))
@@ -11,6 +11,7 @@ Sonarqube-repair can currently repair violations of 11 rules of which 9 are labe
     * [JEE applications should not "getClassLoader"](#jee-applications-should-not-getclassloader-sonar-rule-3032) ([Sonar Rule 3032](https://rules.sonarsource.com/java/RSPEC-3032))
     * ["compareTo" should not return "Integer.MIN_VALUE"](#compareto-should-not-return-integermin_value-sonar-rule-2167) ([Sonar Rule 2167](https://rules.sonarsource.com/java/RSPEC-2167))
     * [Math should not be performed on floats](#math-should-not-be-performed-on-floats-sonar-rule-2164) ([Sonar Rule 2164](https://rules.sonarsource.com/java/RSPEC-2164))
+    * [".equals()" should not be used to test the values of "Atomic" classes](#equals-should-not-be-used-to-test-the-values-of-atomic-classes-sonar-rule-2204) ([Sonar Rule 2204](https://rules.sonarsource.com/java/RSPEC-2204))
 * [Code Smell](#code-smell)
     * [Unused assignments should be removed](#unused-assignments-should-be-removed-sonar-rule-1854) ([Sonar Rule 1854](https://rules.sonarsource.com/java/RSPEC-1854))
     * [Fields in a "Serializable" class should either be transient or serializable](#fields-in-a-serializable-class-should-either-be-transient-or-serializable-sonar-rule-1948) ([Sonar Rule 1948](https://rules.sonarsource.com/java/RSPEC-1948))
@@ -181,6 +182,20 @@ Example:
          float b = 1.0f;
 -        float c = a + b; // Noncompliant, yields 1.6777216E7 not 1.6777217E7
 +        float c = (double) a + (double) b;
+```
+
+-----
+
+#### ".equals()" should not be used to test the values of "Atomic" classes ([Sonar Rule 2204](https://rules.sonarsource.com/java/RSPEC-2204))
+
+Any equality comparison between `AtomicInteger`, `AtomicLong`, or `AtomicBoolean` objects using the method `equals`, i.e., `obj1.equals(obj2)`, is replaced by a binary operator of the kind equals, where the left and right hand operands are calls to the method `.get()` using both objects.
+
+Example:
+```diff
+ 		AtomicInteger aInt1 = new AtomicInteger(0);
+ 		AtomicInteger aInt2 = new AtomicInteger(0);
+-		isEqual = aInt1.equals(aInt2); // Noncompliant
++		isEqual = aInt1.get() == aInt2.get();
 ```
 
 -----

--- a/src/main/java/sonarquberepair/Processors.java
+++ b/src/main/java/sonarquberepair/Processors.java
@@ -7,6 +7,7 @@ import sonarquberepair.processor.spoonbased.ArrayHashCodeAndToStringProcessor;
 import sonarquberepair.processor.spoonbased.BigDecimalDoubleConstructorProcessor;
 import sonarquberepair.processor.spoonbased.CastArithmeticOperandProcessor;
 import sonarquberepair.processor.spoonbased.CompareStringsBoxedTypesWithEqualsProcessor;
+import sonarquberepair.processor.spoonbased.EqualsOnAtomicClassProcessor;
 import sonarquberepair.processor.spoonbased.IteratorNextExceptionProcessor;
 import sonarquberepair.processor.spoonbased.GetClassLoaderProcessor;
 import sonarquberepair.processor.spoonbased.CompareToReturnValueProcessor;
@@ -36,6 +37,7 @@ public class Processors {
 		TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(3032, GetClassLoaderProcessor.class);
 		TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(2167, CompareToReturnValueProcessor.class);
 		TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(2164, MathOnFloatProcessor.class);
+		TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(2204, EqualsOnAtomicClassProcessor.class);
 		return TEMP_RULE_KEY_TO_PROCESSOR;
 	}
 

--- a/src/main/java/sonarquberepair/processor/spoonbased/EqualsOnAtomicClassProcessor.java
+++ b/src/main/java/sonarquberepair/processor/spoonbased/EqualsOnAtomicClassProcessor.java
@@ -1,0 +1,66 @@
+package sonarquberepair.processor.spoonbased;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import sonarquberepair.processor.SQRAbstractProcessor;
+import spoon.reflect.code.BinaryOperatorKind;
+import spoon.reflect.code.CtBinaryOperator;
+import spoon.reflect.code.CtExpression;
+import spoon.reflect.code.CtInvocation;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.reference.CtExecutableReference;
+
+public class EqualsOnAtomicClassProcessor extends SQRAbstractProcessor<CtInvocation> {
+
+	@Override
+	public boolean isToBeProcessed(CtInvocation candidate) {
+		if (candidate.getExecutable().getSignature().equals("equals(java.lang.Object)") &&
+				isAtomicClassRef(candidate.getTarget())) {
+			return true;
+		}
+		return false;
+	}
+
+	@Override
+	public void process(CtInvocation element) {
+		super.process(element);
+
+		CtType atomicClass;
+		if (isAtomicInteger(element.getTarget())) {
+			atomicClass = getFactory().Class().get(AtomicInteger.class);
+		} else if (isAtomicLong(element.getTarget())) {
+			atomicClass = getFactory().Class().get(AtomicLong.class);
+		} else {
+			atomicClass = getFactory().Class().get(AtomicBoolean.class);
+		}
+
+		CtMethod ctMethodToBeCalled = (CtMethod) atomicClass.getMethodsByName("get").get(0);
+		CtExecutableReference ctExecutableReferenceToMethodToBeCalled = getFactory().Executable().createReference(ctMethodToBeCalled);
+
+		CtInvocation leftInvocation = getFactory().Code().createInvocation(element.getTarget(), ctExecutableReferenceToMethodToBeCalled);
+		CtInvocation rightInvocation = getFactory().Code().createInvocation((CtExpression) element.getArguments().get(0), ctExecutableReferenceToMethodToBeCalled);
+
+		CtBinaryOperator newCtBinaryOperator = getFactory().Code().createBinaryOperator(leftInvocation, rightInvocation, BinaryOperatorKind.EQ);
+
+		element.replace(newCtBinaryOperator);
+	}
+
+	private boolean isAtomicClassRef(CtExpression ctExpression) {
+		return isAtomicInteger(ctExpression) || isAtomicLong(ctExpression) || isAtomicBoolean(ctExpression);
+	}
+
+	private boolean isAtomicInteger(CtExpression ctExpression) {
+		return ctExpression.getType().getQualifiedName().equals("java.util.concurrent.atomic.AtomicInteger");
+	}
+
+	private boolean isAtomicLong(CtExpression ctExpression) {
+		return ctExpression.getType().getQualifiedName().equals("java.util.concurrent.atomic.AtomicLong");
+	}
+
+	private boolean isAtomicBoolean(CtExpression ctExpression) {
+		return ctExpression.getType().getQualifiedName().equals("java.util.concurrent.atomic.AtomicBoolean");
+	}
+
+}

--- a/src/test/java/sonarquberepair/processor/spoonbased/EqualsOnAtomicClassProcessorTest.java
+++ b/src/test/java/sonarquberepair/processor/spoonbased/EqualsOnAtomicClassProcessorTest.java
@@ -1,0 +1,29 @@
+package sonarquberepair.processor.spoonbased;
+
+import org.junit.Test;
+import org.sonar.java.checks.EqualsOnAtomicClassCheck;
+import org.sonar.java.checks.verifier.JavaCheckVerifier;
+import sonarquberepair.Constants;
+import sonarquberepair.Main;
+import sonarquberepair.TestHelper;
+
+public class EqualsOnAtomicClassProcessorTest {
+
+	@Test
+	public void test() throws Exception {
+		String fileName = "EqualsOnAtomicClass.java";
+		String pathToBuggyFile = Constants.PATH_TO_FILE + fileName;
+		String pathToRepairedFile = Constants.WORKSPACE + "/spooned/" + fileName;
+
+		JavaCheckVerifier.verify(pathToBuggyFile, new EqualsOnAtomicClassCheck());
+		Main.main(new String[]{
+				"--originalFilesPath", pathToBuggyFile,
+				"--projectKey", Constants.PROJECT_KEY,
+				"--ruleKeys", "2204",
+				"--prettyPrintingStrategy", "SNIPER",
+				"--workspace", Constants.WORKSPACE});
+		TestHelper.removeComplianceComments(pathToRepairedFile);
+		JavaCheckVerifier.verifyNoIssue(pathToRepairedFile, new EqualsOnAtomicClassCheck());
+	}
+
+}

--- a/src/test/resources/EqualsOnAtomicClass.java
+++ b/src/test/resources/EqualsOnAtomicClass.java
@@ -1,0 +1,30 @@
+// Test for rule s2204
+// Tests from https://github.com/SonarSource/sonar-java/blob/master/java-checks-test-sources/src/main/java/checks/EqualsOnAtomicClassCheck.java
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+class EqualsOnAtomicClass {
+
+	void method() {
+		boolean isEqual = false;
+
+		AtomicBoolean abool1 = new AtomicBoolean(true);
+		AtomicBoolean abool2 = new AtomicBoolean(true);
+		isEqual = abool1.equals(abool2); // Noncompliant {{Use ".get()" to retrieve the value and compare it instead.}}
+
+		AtomicInteger aInt1 = new AtomicInteger(0);
+		AtomicInteger aInt2 = new AtomicInteger(0);
+		isEqual = aInt1.equals(aInt2); // Noncompliant
+
+		AtomicLong aLong1 = new AtomicLong(0);
+		AtomicLong aLong2 = new AtomicLong(0);
+		isEqual = aLong1.equals(aLong2); // Noncompliant
+
+		Integer int1 = new Integer(0);
+		Integer int2 = new Integer(0);
+		isEqual = int1.equals(int2);
+	}
+
+}


### PR DESCRIPTION
This PR adds a processor for the rule [".equals()" should not be used to test the values of "Atomic" classes](https://rules.sonarsource.com/java/RSPEC-2204).

Transformation:

```diff
 // Test for rule s2204
 // Tests from https://github.com/SonarSource/sonar-java/blob/master/java-checks-test-sources/src/main/java/checks/EqualsOnAtomicClassCheck.java
 
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 class EqualsOnAtomicClass {
 
 	void method() {
 		boolean isEqual = false;
 
 		AtomicBoolean abool1 = new AtomicBoolean(true);
 		AtomicBoolean abool2 = new AtomicBoolean(true);
-		isEqual = abool1.equals(abool2); // Noncompliant {{Use ".get()" to retrieve the value and compare it instead.}}
+		isEqual = abool1.get() == abool2.get(); 
 
 		AtomicInteger aInt1 = new AtomicInteger(0);
 		AtomicInteger aInt2 = new AtomicInteger(0);
-		isEqual = aInt1.equals(aInt2); // Noncompliant
+		isEqual = aInt1.get() == aInt2.get(); 
 
 		AtomicLong aLong1 = new AtomicLong(0);
 		AtomicLong aLong2 = new AtomicLong(0);
-		isEqual = aLong1.equals(aLong2); // Noncompliant
+		isEqual = aLong1.get() == aLong2.get(); 
 
 		Integer int1 = new Integer(0);
 		Integer int2 = new Integer(0);
 		isEqual = int1.equals(int2);
 	}
 
 }
```