### PR TITLE
Add SynchronizationOnStringOrBoxedProcessor (SonarRule 1860)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Sonarqube-repair is a collection of java code analyses and transformations made with the [Spoon](https://github.com/INRIA/spoon) library to repair violations of rules contained in [SonarQube](https://rules.sonarsource.com).
 
 ## Handled rules
-Sonarqube-repair can currently repair violations of 12 rules of which 10 are labeled as `BUG` and 2 as `Code Smell`. [Check out the handled rules](/docs/HANDLED_RULES.md).
+Sonarqube-repair can currently repair violations of 13 rules of which 11 are labeled as `BUG` and 2 as `Code Smell`. [Check out the handled rules](/docs/HANDLED_RULES.md).
 
 ## Getting started
 

--- a/docs/HANDLED_RULES.md
+++ b/docs/HANDLED_RULES.md
@@ -203,7 +203,7 @@ Example:
 
 #### Synchronization should not be based on Strings or boxed primitives ([Sonar Rule 1860](https://rules.sonarsource.com/java/RSPEC-1860))
 
-Objects which are pooled, such as Strings or boxed primitives and potentially reused should not be used for synchronization, since that can cause deadlocks. The transformation will do the following. If the lock is a field of the current class where the synchronization block is in, then it will simply adding a new field as an Object lock. If the lock is obtained from another object through the get method, it will add a new field for the new object lock and a new method return the object. 
+Objects which are pooled, such as Strings or boxed primitives, and potentially reused should not be used for synchronization, since they can cause deadlocks. The transformation will do the following. If the lock is a field of the current class where the synchronization block is in, then it will simply add a new field as an `Object` lock. If the lock is obtained from another object through the `get` method, it will add a new field for the new `Object` lock and a new method to get the object. 
 
 Example:
 ```diff

--- a/docs/HANDLED_RULES.md
+++ b/docs/HANDLED_RULES.md
@@ -1,5 +1,5 @@
 ## Handled rules
-Sonarqube-repair can currently repair violations of 12 rules of which 10 are labeled as `BUG` and 2 as `Code Smell`:
+Sonarqube-repair can currently repair violations of 13 rules of which 11 are labeled as `BUG` and 2 as `Code Smell`:
 
 * [Bug](#bug)
     * [Resources should be closed](#resources-should-be-closed-sonar-rule-2095) ([Sonar Rule 2095](https://rules.sonarsource.com/java/RSPEC-2095))
@@ -11,6 +11,7 @@ Sonarqube-repair can currently repair violations of 12 rules of which 10 are lab
     * [JEE applications should not "getClassLoader"](#jee-applications-should-not-getclassloader-sonar-rule-3032) ([Sonar Rule 3032](https://rules.sonarsource.com/java/RSPEC-3032))
     * ["compareTo" should not return "Integer.MIN_VALUE"](#compareto-should-not-return-integermin_value-sonar-rule-2167) ([Sonar Rule 2167](https://rules.sonarsource.com/java/RSPEC-2167))
     * [Math should not be performed on floats](#math-should-not-be-performed-on-floats-sonar-rule-2164) ([Sonar Rule 2164](https://rules.sonarsource.com/java/RSPEC-2164))
+    * [Synchronization should not be based on Strings or boxed primitives](#Synchronization-should-not-be-based-on-Strings-or-boxed-primitives) ([Sonar Rule 1860](https://rules.sonarsource.com/java/tag/multi-threading/RSPEC-1860))
     * [".equals()" should not be used to test the values of "Atomic" classes](#equals-should-not-be-used-to-test-the-values-of-atomic-classes-sonar-rule-2204) ([Sonar Rule 2204](https://rules.sonarsource.com/java/RSPEC-2204))
 * [Code Smell](#code-smell)
     * [Unused assignments should be removed](#unused-assignments-should-be-removed-sonar-rule-1854) ([Sonar Rule 1854](https://rules.sonarsource.com/java/RSPEC-1854))
@@ -196,6 +197,38 @@ Example:
  		AtomicInteger aInt2 = new AtomicInteger(0);
 -		isEqual = aInt1.equals(aInt2); // Noncompliant
 +		isEqual = aInt1.get() == aInt2.get();
+```
+
+-----
+
+#### Synchronization should not be based on Strings or boxed primitives ([Sonar Rule 1860](https://rules.sonarsource.com/java/RSPEC-1860))
+
+Objects which are pooled and potentially reused should not be used for synchronization. If they are, it can cause unrelated threads to deadlock with unhelpful stacktraces. Specifically, String literals, and boxed primitives such as Integers should not be used as lock objects because they are pooled and reused.
+
+Example:
+```diff
+-  private final Boolean bLock = Boolean.FALSE;
++  private final Object bLockLegal = new Object();
+   private final InnerClass i = new InnerClass();
+-  void method1() {
+-    synchronized(bLock) {}
+-    synchronized(i.getLock()){}
+-  }
++  void method1() {
++    synchronized(bLockLegal) {}
++    synchronized(i.getLockLegal()){}
++  }
+   class InnerClass {
+        public Boolean innerLock = Boolean.FALSE;
++       public Object innerLockLegal = new Object();
+
+        public Boolean getLock() {
+            return this.innerLock;
+        }
++       public Object getLockLegal() {
++           return this.innerLockLegal;
++       }
+  }
 ```
 
 -----

--- a/docs/HANDLED_RULES.md
+++ b/docs/HANDLED_RULES.md
@@ -11,7 +11,7 @@ Sonarqube-repair can currently repair violations of 13 rules of which 11 are lab
     * [JEE applications should not "getClassLoader"](#jee-applications-should-not-getclassloader-sonar-rule-3032) ([Sonar Rule 3032](https://rules.sonarsource.com/java/RSPEC-3032))
     * ["compareTo" should not return "Integer.MIN_VALUE"](#compareto-should-not-return-integermin_value-sonar-rule-2167) ([Sonar Rule 2167](https://rules.sonarsource.com/java/RSPEC-2167))
     * [Math should not be performed on floats](#math-should-not-be-performed-on-floats-sonar-rule-2164) ([Sonar Rule 2164](https://rules.sonarsource.com/java/RSPEC-2164))
-    * [Synchronization should not be based on Strings or boxed primitives](#Synchronization-should-not-be-based-on-Strings-or-boxed-primitives) ([Sonar Rule 1860](https://rules.sonarsource.com/java/tag/multi-threading/RSPEC-1860))
+    * [Synchronization should not be based on Strings or boxed primitives](#synchronization-should-not-be-based-on-Strings-or-boxed-primitives) ([Sonar Rule 1860](https://rules.sonarsource.com/java/tag/multi-threading/RSPEC-1860))
     * [".equals()" should not be used to test the values of "Atomic" classes](#equals-should-not-be-used-to-test-the-values-of-atomic-classes-sonar-rule-2204) ([Sonar Rule 2204](https://rules.sonarsource.com/java/RSPEC-2204))
 * [Code Smell](#code-smell)
     * [Unused assignments should be removed](#unused-assignments-should-be-removed-sonar-rule-1854) ([Sonar Rule 1854](https://rules.sonarsource.com/java/RSPEC-1854))
@@ -203,11 +203,11 @@ Example:
 
 #### Synchronization should not be based on Strings or boxed primitives ([Sonar Rule 1860](https://rules.sonarsource.com/java/RSPEC-1860))
 
-Objects which are pooled and potentially reused should not be used for synchronization. If they are, it can cause unrelated threads to deadlock with unhelpful stacktraces. Specifically, String literals, and boxed primitives such as Integers should not be used as lock objects because they are pooled and reused.
+Objects which are pooled, such as Strings or boxed primitives and potentially reused should not be used for synchronization, since that can cause deadlocks. The transformation will do the following. If the lock is a field of the current class where the synchronization block is in, then it will simply adding a new field as an Object lock. If the lock is obtained from another object through the get method, it will add a new field for the new object lock and a new method return the object. 
 
 Example:
 ```diff
--  private final Boolean bLock = Boolean.FALSE;
+   private final Boolean bLock = Boolean.FALSE;
 +  private final Object bLockLegal = new Object();
    private final InnerClass i = new InnerClass();
 -  void method1() {

--- a/docs/HANDLED_RULES.md
+++ b/docs/HANDLED_RULES.md
@@ -11,7 +11,7 @@ Sonarqube-repair can currently repair violations of 13 rules of which 11 are lab
     * [JEE applications should not "getClassLoader"](#jee-applications-should-not-getclassloader-sonar-rule-3032) ([Sonar Rule 3032](https://rules.sonarsource.com/java/RSPEC-3032))
     * ["compareTo" should not return "Integer.MIN_VALUE"](#compareto-should-not-return-integermin_value-sonar-rule-2167) ([Sonar Rule 2167](https://rules.sonarsource.com/java/RSPEC-2167))
     * [Math should not be performed on floats](#math-should-not-be-performed-on-floats-sonar-rule-2164) ([Sonar Rule 2164](https://rules.sonarsource.com/java/RSPEC-2164))
-    * [Synchronization should not be based on Strings or boxed primitives](#synchronization-should-not-be-based-on-Strings-or-boxed-primitives) ([Sonar Rule 1860](https://rules.sonarsource.com/java/tag/multi-threading/RSPEC-1860))
+    * [Synchronization should not be based on Strings or boxed primitives](#synchronization-should-not-be-based-on-Strings-or-boxed-primitives-sonar-rule-1860) ([Sonar Rule 1860](https://rules.sonarsource.com/java/tag/multi-threading/RSPEC-1860))
     * [".equals()" should not be used to test the values of "Atomic" classes](#equals-should-not-be-used-to-test-the-values-of-atomic-classes-sonar-rule-2204) ([Sonar Rule 2204](https://rules.sonarsource.com/java/RSPEC-2204))
 * [Code Smell](#code-smell)
     * [Unused assignments should be removed](#unused-assignments-should-be-removed-sonar-rule-1854) ([Sonar Rule 1854](https://rules.sonarsource.com/java/RSPEC-1854))

--- a/src/main/java/sonarquberepair/Processors.java
+++ b/src/main/java/sonarquberepair/Processors.java
@@ -12,6 +12,7 @@ import sonarquberepair.processor.spoonbased.IteratorNextExceptionProcessor;
 import sonarquberepair.processor.spoonbased.GetClassLoaderProcessor;
 import sonarquberepair.processor.spoonbased.CompareToReturnValueProcessor;
 import sonarquberepair.processor.spoonbased.MathOnFloatProcessor;
+import sonarquberepair.processor.spoonbased.SynchronizationOnStringOrBoxedProcessor;
 
 import spoon.processing.Processor;
 
@@ -38,6 +39,7 @@ public class Processors {
 		TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(2167, CompareToReturnValueProcessor.class);
 		TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(2164, MathOnFloatProcessor.class);
 		TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(2204, EqualsOnAtomicClassProcessor.class);
+		TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(1860, SynchronizationOnStringOrBoxedProcessor.class);
 		return TEMP_RULE_KEY_TO_PROCESSOR;
 	}
 

--- a/src/main/java/sonarquberepair/processor/spoonbased/SynchronizationOnStringOrBoxedProcessor.java
+++ b/src/main/java/sonarquberepair/processor/spoonbased/SynchronizationOnStringOrBoxedProcessor.java
@@ -11,7 +11,6 @@ import spoon.reflect.code.CtSynchronized;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtFieldRead;
 import spoon.reflect.code.CtInvocation;
-import spoon.reflect.code.CtReturn;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtVariableReference;
@@ -25,11 +24,10 @@ import java.util.Map;
 public class SynchronizationOnStringOrBoxedProcessor extends SQRAbstractProcessor<CtSynchronized> {
     private Map<Integer,CtVariableReference> old2NewFields;
     private Map<Integer,CtExecutableReference> old2NewMethods;
-    private HashSet<String> invalidTypes;
 
     public SynchronizationOnStringOrBoxedProcessor() {
-        this.old2NewFields = new HashMap<Integer,CtVariableReference>();
-        this.old2NewMethods = new HashMap<Integer,CtExecutableReference>();
+        this.old2NewFields = new HashMap<>();
+        this.old2NewMethods = new HashMap<>();
     }
 
     @Override

--- a/src/main/java/sonarquberepair/processor/spoonbased/SynchronizationOnStringOrBoxedProcessor.java
+++ b/src/main/java/sonarquberepair/processor/spoonbased/SynchronizationOnStringOrBoxedProcessor.java
@@ -1,0 +1,116 @@
+package sonarquberepair.processor.spoonbased;
+
+import sonarquberepair.processor.SQRAbstractProcessor;
+import spoon.reflect.declaration.CtExecutable;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.declaration.ModifierKind;
+import spoon.reflect.code.CtReturn;
+import spoon.reflect.factory.Factory;
+import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.reflect.code.CtSynchronized;
+import spoon.reflect.code.CtExpression;
+import spoon.reflect.code.CtFieldRead;
+import spoon.reflect.code.CtInvocation;
+import spoon.reflect.code.CtReturn;
+import spoon.reflect.declaration.CtField;
+import spoon.reflect.reference.CtExecutableReference;
+import spoon.reflect.reference.CtVariableReference;
+import spoon.reflect.declaration.CtVariable;
+import spoon.reflect.declaration.CtMethod;
+
+import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
+
+public class SynchronizationOnStringOrBoxedProcessor extends SQRAbstractProcessor<CtSynchronized> {
+    private Map<Integer,CtVariableReference> old2NewFields;
+    private Map<Integer,CtExecutableReference> old2NewMethods;
+    private HashSet<String> invalidTypes;
+
+    public SynchronizationOnStringOrBoxedProcessor() {
+        this.old2NewFields = new HashMap<Integer,CtVariableReference>();
+        this.old2NewMethods = new HashMap<Integer,CtExecutableReference>();
+    }
+
+    @Override
+    public boolean isToBeProcessed(CtSynchronized element) {
+        CtExpression<?> expression = element.getExpression();
+        if (!expression.getType().toString().equals("String") && !expression.getType().unbox().isPrimitive()) {
+            return false;
+        }
+        CtFieldRead<?> fieldRead;
+        if (expression instanceof CtFieldRead) {
+            fieldRead = (CtFieldRead) expression;
+        } else if (expression instanceof CtInvocation) {
+            CtExecutable<?> method = ((CtInvocation)expression).getExecutable().getDeclaration();
+            CtExpression<?> returnExpression = ((CtReturn)method.getElements(new TypeFilter(CtReturn.class)).get(0)).getReturnedExpression();
+            if (returnExpression instanceof CtFieldRead) {
+                fieldRead = (CtFieldRead) returnExpression;
+            } else {
+                /* don't support multiple recursive call */
+                return false; 
+            }
+        } else {
+            return false;
+        }
+
+        CtField<?> field = fieldRead.getVariable().getDeclaration();
+        if(field != null) {
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override   
+    public void process(CtSynchronized element) {
+        super.process(element);
+        CtExpression<?> expression = element.getExpression();
+        Factory factory = element.getFactory();
+        CtFieldRead<?> fieldRead4Update;
+        if (expression instanceof CtFieldRead) {
+            fieldRead4Update = (CtFieldRead) expression;
+        } else {
+            CtExecutable<?> method = ((CtInvocation)expression).getExecutable().getDeclaration();
+            CtExpression<?> oldReturnExpression =  ((CtReturn)method.getElements(new TypeFilter(CtReturn.class)).get(0)).getReturnedExpression();
+            CtFieldRead<?> oldFieldRead = (CtFieldRead) oldReturnExpression;
+            CtType<?> c = (CtType)oldFieldRead.getParent(CtType.class);
+            CtMethod<?> newMethod = (CtMethod)method.clone();
+
+            if (!old2NewMethods.containsKey(method.hashCode())) {
+                newMethod.setSimpleName(method.getSimpleName() + "Legal");
+                newMethod.setType((((CtType)factory.Class().get(Object.class)).getReference()));
+                c.addMethod(newMethod);
+                ((CtInvocation)expression).setExecutable(((CtExecutable)newMethod).getReference());
+            } else {
+                ((CtInvocation)expression).setExecutable(old2NewMethods.get(method.hashCode()));
+            }
+
+            CtExpression<?> returnExpression = ((CtReturn)newMethod.getElements(new TypeFilter(CtReturn.class)).get(0)).getReturnedExpression();
+            fieldRead4Update = (CtFieldRead) returnExpression;
+
+        } 
+        this.updateFieldRead(fieldRead4Update);
+    }
+
+    private void updateFieldRead(CtFieldRead<?> fieldRead) {
+        if (!this.old2NewFields.containsKey(fieldRead.getVariable().hashCode())) {
+            CtField<?> field = fieldRead.getVariable().getDeclaration();
+            CtType<?> c = (CtType)field.getParent(CtType.class);
+
+            Factory factory = fieldRead.getFactory();
+
+            ModifierKind[] modArr = new ModifierKind[field.getModifiers().size()];
+            CtField<?> newField = factory.Code().createCtField(field.getSimpleName() + "Legal",
+                                                        factory.Class().get(Object.class).getReference(),
+                                                        "new Object()",
+                                                        field.getModifiers().toArray(modArr));
+
+            c.addFieldAtTop(newField);
+            old2NewFields.put(fieldRead.getVariable().hashCode(),((CtVariable)newField).getReference());
+            fieldRead.setVariable(((CtVariable)newField).getReference());
+        } else {
+            fieldRead.setVariable(old2NewFields.get(fieldRead.getVariable().hashCode()));
+        }
+    }
+}

--- a/src/test/java/sonarquberepair/processor/spoonbased/SynchronizationOnStringOrBoxedProcessorTest.java
+++ b/src/test/java/sonarquberepair/processor/spoonbased/SynchronizationOnStringOrBoxedProcessorTest.java
@@ -1,0 +1,28 @@
+package sonarquberepair.processor.spoonbased;
+
+import org.junit.Test;
+import org.sonar.java.checks.SynchronizationOnStringOrBoxedCheck;
+import org.sonar.java.checks.verifier.JavaCheckVerifier;
+import sonarquberepair.Constants;
+import sonarquberepair.Main;
+import sonarquberepair.TestHelper;
+
+public class SynchronizationOnStringOrBoxedProcessorTest {
+
+	@Test
+	public void test() throws Exception {
+		String fileName = "SynchronizationOnStringOrBoxed.java";
+		String pathToBuggyFile = Constants.PATH_TO_FILE + fileName;
+		String pathToRepairedFile = Constants.WORKSPACE + "/spooned/" + fileName;
+
+		JavaCheckVerifier.verify(pathToBuggyFile, new SynchronizationOnStringOrBoxedCheck());
+		Main.main(new String[]{
+				"--originalFilesPath", pathToBuggyFile,
+				"--projectKey", Constants.PROJECT_KEY,
+				"--ruleKeys", "1860",
+				"--workspace", Constants.WORKSPACE});
+		TestHelper.removeComplianceComments(pathToRepairedFile);
+		JavaCheckVerifier.verifyNoIssue(pathToRepairedFile, new SynchronizationOnStringOrBoxedCheck());
+	}
+
+}

--- a/src/test/resources/SynchronizationOnStringOrBoxed.java
+++ b/src/test/resources/SynchronizationOnStringOrBoxed.java
@@ -1,0 +1,51 @@
+class SynchronizationOnStringOrBoxed {
+  
+  private final Boolean bLock = Boolean.FALSE;
+  private final Integer iLock = Integer.valueOf(0);
+  final String sLock = "LOCK";
+  private final Object oLock = new Object();
+  private final InnerClass i = new InnerClass();
+
+  class InnerClass {
+    public Boolean innerLock = Boolean.FALSE;
+    private SynchronizationOnStringOrBoxed outerClass = new SynchronizationOnStringOrBoxed();
+
+    public void method2() {
+      synchronized(this.outerClass.sLock) {  // Noncompliant
+        // ...
+      }
+    }
+
+    public Boolean getLock() {
+      return this.innerLock;
+    }
+  }
+
+  void method1() {
+    
+    synchronized(bLock) {  // Noncompliant [[sc=18;ec=23]] {{Synchronize on a new "Object" instead.}}
+      // ...
+    }
+    synchronized(iLock) {  // Noncompliant
+      // ...
+    }
+    synchronized(sLock) {  // Noncompliant
+      // ...
+    }
+    synchronized(oLock) { 
+      // ...
+    }
+    synchronized(i.getLock()) { // Noncompliant
+
+    }
+  }
+  
+  void method3() {
+    synchronized(sLock) {  // Noncompliant
+      // ...
+    }
+    synchronized(i.getLock()) { // Noncompliant
+
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a processor for the rule [Synchronization should not be based on Strings or boxed primitives](https://rules.sonarsource.com/java/RSPEC-1860) .

```diff
+  private final Object bLockLegal = new Object();
    private final InnerClass i = new InnerClass();
-  void method1() {
-    synchronized(bLock) {}
-    synchronized(i.getLock()){}
-  }
+  void method1() {
+    synchronized(bLockLegal) {}
+    synchronized(i.getLockLegal()){}
+  }
   class InnerClass {
        public Boolean innerLock = Boolean.FALSE;
+       public Object innerLockLegal = new Object();
        public Boolean getLock() {
            return this.innerLock;
        }
+       public Object getLockLegal() {
+           return this.innerLockLegal;
+       }
  }
```