### PR TITLE
Add SynchronizationOnGetClassProcessor (SonarRule 3067)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Sonarqube-repair is a collection of java code analyses and transformations made with the [Spoon](https://github.com/INRIA/spoon) library to repair violations of rules contained in [SonarQube](https://rules.sonarsource.com).
 
 ## Handled rules
-Sonarqube-repair can currently repair violations of 13 rules of which 11 are labeled as `BUG` and 2 as `Code Smell`. [Check out the handled rules](/docs/HANDLED_RULES.md).
+Sonarqube-repair can currently repair violations of 14 rules of which 12 are labeled as `BUG` and 2 as `Code Smell`. [Check out the handled rules](/docs/HANDLED_RULES.md).
 
 ## Getting started
 

--- a/docs/HANDLED_RULES.md
+++ b/docs/HANDLED_RULES.md
@@ -245,17 +245,16 @@ class SynchronizationOnGetClass {
 -    InnerClass i = new InnerClass();
 -    synchronized (i.getObject().getClass()) { // Noncompliant - object's modifier is unknown, assume non-final nor enum
 -  }
-+    public void method1() {
-+        InnerClass i = new InnerClass();
-+        synchronized(Object.class) {}
++  public void method1() {
++    InnerClass i = new InnerClass();
++    synchronized(Object.class) {}
 +  }
- 
--   public void method2() {
--     synchronized (getClass()) {}
--   }
-+   public void method2() {
-+     synchronized(SynchronizationOnGetClass.class) {}
-+   }
+-  public void method2() {
+-    synchronized (getClass()) {}
+-  }
++  public void method2() {
++    synchronized(SynchronizationOnGetClass.class) {}
++  }
 }
 ```
 

--- a/docs/HANDLED_RULES.md
+++ b/docs/HANDLED_RULES.md
@@ -1,5 +1,5 @@
 ## Handled rules
-Sonarqube-repair can currently repair violations of 13 rules of which 11 are labeled as `BUG` and 2 as `Code Smell`:
+Sonarqube-repair can currently repair violations of 14 rules of which 12 are labeled as `BUG` and 2 as `Code Smell`:
 
 * [Bug](#bug)
     * [Resources should be closed](#resources-should-be-closed-sonar-rule-2095) ([Sonar Rule 2095](https://rules.sonarsource.com/java/RSPEC-2095))
@@ -13,7 +13,7 @@ Sonarqube-repair can currently repair violations of 13 rules of which 11 are lab
     * [Math should not be performed on floats](#math-should-not-be-performed-on-floats-sonar-rule-2164) ([Sonar Rule 2164](https://rules.sonarsource.com/java/RSPEC-2164))
     * [Synchronization should not be based on Strings or boxed primitives](#synchronization-should-not-be-based-on-Strings-or-boxed-primitives-sonar-rule-1860) ([Sonar Rule 1860](https://rules.sonarsource.com/java/tag/multi-threading/RSPEC-1860))
     * [".equals()" should not be used to test the values of "Atomic" classes](#equals-should-not-be-used-to-test-the-values-of-atomic-classes-sonar-rule-2204) ([Sonar Rule 2204](https://rules.sonarsource.com/java/RSPEC-2204))
-    * ["getClass" should not be used for synchronization](#getClass-should-not-be-used-for-synchronization-sonar-rule-3067) ([Sonar Rule 3067](https://rules.sonarsource.com/java/type/Bug/RSPEC-3067))
+    * ["getClass" should not be used for synchronization](#getclass-should-not-be-used-for-synchronization-sonar-rule-3067) ([Sonar Rule 3067](https://rules.sonarsource.com/java/type/Bug/RSPEC-3067))
 * [Code Smell](#code-smell)
     * [Unused assignments should be removed](#unused-assignments-should-be-removed-sonar-rule-1854) ([Sonar Rule 1854](https://rules.sonarsource.com/java/RSPEC-1854))
     * [Fields in a "Serializable" class should either be transient or serializable](#fields-in-a-serializable-class-should-either-be-transient-or-serializable-sonar-rule-1948) ([Sonar Rule 1948](https://rules.sonarsource.com/java/RSPEC-1948))

--- a/docs/HANDLED_RULES.md
+++ b/docs/HANDLED_RULES.md
@@ -13,6 +13,7 @@ Sonarqube-repair can currently repair violations of 13 rules of which 11 are lab
     * [Math should not be performed on floats](#math-should-not-be-performed-on-floats-sonar-rule-2164) ([Sonar Rule 2164](https://rules.sonarsource.com/java/RSPEC-2164))
     * [Synchronization should not be based on Strings or boxed primitives](#synchronization-should-not-be-based-on-Strings-or-boxed-primitives-sonar-rule-1860) ([Sonar Rule 1860](https://rules.sonarsource.com/java/tag/multi-threading/RSPEC-1860))
     * [".equals()" should not be used to test the values of "Atomic" classes](#equals-should-not-be-used-to-test-the-values-of-atomic-classes-sonar-rule-2204) ([Sonar Rule 2204](https://rules.sonarsource.com/java/RSPEC-2204))
+    * ["getClass" should not be used for synchronization](#getClass-should-not-be-used-for-synchronization-sonar-rule-3067) ([Sonar Rule 3067](https://rules.sonarsource.com/java/type/Bug/RSPEC-3067))
 * [Code Smell](#code-smell)
     * [Unused assignments should be removed](#unused-assignments-should-be-removed-sonar-rule-1854) ([Sonar Rule 1854](https://rules.sonarsource.com/java/RSPEC-1854))
     * [Fields in a "Serializable" class should either be transient or serializable](#fields-in-a-serializable-class-should-either-be-transient-or-serializable-sonar-rule-1948) ([Sonar Rule 1948](https://rules.sonarsource.com/java/RSPEC-1948))
@@ -233,6 +234,32 @@ Example:
 
 -----
 
+#### "getClass" should not be used for synchronization ([Sonar Rule 3067](https://rules.sonarsource.com/java/RSPEC-3067))
+
+
+
+Example:
+```diff
+class SynchronizationOnGetClass {
+-  public void method1() {
+-    InnerClass i = new InnerClass();
+-    synchronized (i.getObject().getClass()) { // Noncompliant - object's modifier is unknown, assume non-final nor enum
+-  }
++    public void method1() {
++        InnerClass i = new InnerClass();
++        synchronized(Object.class) {}
++  }
+ 
+-   public void method2() {
+-     synchronized (getClass()) {}
+-   }
++   public void method2() {
++     synchronized(SynchronizationOnGetClass.class) {}
++   }
+}
+```
+
+-----
 ### *Code Smell*
 
 #### Unused assignments should be removed ([Sonar Rule 1854](https://rules.sonarsource.com/java/RSPEC-1854))

--- a/docs/HANDLED_RULES.md
+++ b/docs/HANDLED_RULES.md
@@ -236,7 +236,7 @@ Example:
 
 #### "getClass" should not be used for synchronization ([Sonar Rule 3067](https://rules.sonarsource.com/java/RSPEC-3067))
 
-
+Any invocation using getClass will be typechecked if the object's invoked by `getClass` is final or an enum. If not, the invocation will be transformed to `.class` instead of `getClass`.
 
 Example:
 ```diff

--- a/src/main/java/sonarquberepair/Processors.java
+++ b/src/main/java/sonarquberepair/Processors.java
@@ -13,6 +13,7 @@ import sonarquberepair.processor.spoonbased.GetClassLoaderProcessor;
 import sonarquberepair.processor.spoonbased.CompareToReturnValueProcessor;
 import sonarquberepair.processor.spoonbased.MathOnFloatProcessor;
 import sonarquberepair.processor.spoonbased.SynchronizationOnStringOrBoxedProcessor;
+import sonarquberepair.processor.spoonbased.SynchronizationOnGetClassProcessor;
 
 import spoon.processing.Processor;
 
@@ -40,6 +41,7 @@ public class Processors {
 		TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(2164, MathOnFloatProcessor.class);
 		TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(2204, EqualsOnAtomicClassProcessor.class);
 		TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(1860, SynchronizationOnStringOrBoxedProcessor.class);
+		TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(3067, SynchronizationOnGetClassProcessor.class);
 		return TEMP_RULE_KEY_TO_PROCESSOR;
 	}
 

--- a/src/main/java/sonarquberepair/processor/spoonbased/SynchronizationOnGetClassProcessor.java
+++ b/src/main/java/sonarquberepair/processor/spoonbased/SynchronizationOnGetClassProcessor.java
@@ -1,0 +1,72 @@
+package sonarquberepair.processor.spoonbased;
+
+import sonarquberepair.processor.SQRAbstractProcessor;
+import spoon.reflect.factory.Factory;
+import spoon.reflect.code.CtInvocation;
+import spoon.reflect.code.CtSynchronized;
+import spoon.reflect.code.CtFieldAccess;
+import spoon.reflect.code.CtExpression;
+import spoon.reflect.declaration.ModifierKind;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.reference.CtTypeReference;
+
+import java.util.Set;
+
+public class SynchronizationOnGetClassProcessor extends SQRAbstractProcessor<CtSynchronized> {
+
+	@Override
+	public boolean isToBeProcessed(CtSynchronized element) {
+		CtExpression<?> expression = element.getExpression();
+		if (expression.toString().endsWith("getClass()")) {
+			CtExpression target = ((CtInvocation)expression).getTarget();
+			if (target != null) {
+				CtType<?> type = target.getType().getDeclaration();
+				if (type == null) {
+					/* not in class path, but still fail according to SonarQube */
+					return true;
+				}
+				if (this.enclosingTypeIsFinalOrEnum(type)) {
+					return false;
+				} else {
+					return true;
+				}
+			} else {
+				/* implicit this */
+				CtType<?> type = ((CtType)element.getParent(CtType.class));
+				if (this.enclosingTypeIsFinalOrEnum(type)) {
+					return false;
+				} else {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	@Override	
+	public void process(CtSynchronized element) {
+		super.process(element);
+		CtExpression<?> expression = element.getExpression();
+		CtTypeReference<?> typeRef;
+		if (expression.toString().equals("getClass()")) {
+			/* implicit this case */
+			typeRef = ((CtType)expression.getParent(CtType.class)).getReference();
+		} else {
+			typeRef = ((CtInvocation)expression).getTarget().getType();
+		}
+		
+		Factory factory = element.getFactory();
+		CtFieldAccess<?> classAccess = factory.Code().createClassAccess(typeRef);
+
+		expression.replace(classAccess);
+	}
+
+	private boolean enclosingTypeIsFinalOrEnum(CtType<?> type) {
+		Set<ModifierKind> modifiers = type.getModifiers();
+		if (modifiers.contains(ModifierKind.valueOf("FINAL")) || type.isEnum()) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+}

--- a/src/test/java/sonarquberepair/processor/spoonbased/SynchronizationOnGetClassProcessorTest.java
+++ b/src/test/java/sonarquberepair/processor/spoonbased/SynchronizationOnGetClassProcessorTest.java
@@ -1,0 +1,28 @@
+package sonarquberepair.processor.spoonbased;
+
+import org.junit.Test;
+import org.sonar.java.checks.synchronization.SynchronizationOnGetClassCheck;
+import org.sonar.java.checks.verifier.JavaCheckVerifier;
+import sonarquberepair.Constants;
+import sonarquberepair.Main;
+import sonarquberepair.TestHelper;
+
+public class SynchronizationOnGetClassProcessorTest {
+
+	@Test
+	public void test() throws Exception {
+		String fileName = "SynchronizationOnGetClass.java";
+		String pathToBuggyFile = Constants.PATH_TO_FILE + fileName;
+		String pathToRepairedFile = Constants.WORKSPACE + "/spooned/" + fileName;
+
+		JavaCheckVerifier.verify(pathToBuggyFile, new SynchronizationOnGetClassCheck());
+        Main.main(new String[]{
+                "--originalFilesPath",pathToBuggyFile,
+                "--projectKey", Constants.PROJECT_KEY,
+                "--ruleKeys","3067",
+                "--workspace",Constants.WORKSPACE});
+        TestHelper.removeComplianceComments(pathToRepairedFile);
+        JavaCheckVerifier.verifyNoIssue(pathToRepairedFile, new SynchronizationOnGetClassCheck());
+	}
+
+}

--- a/src/test/java/sonarquberepair/processor/spoonbased/SynchronizationOnGetClassProcessorTest.java
+++ b/src/test/java/sonarquberepair/processor/spoonbased/SynchronizationOnGetClassProcessorTest.java
@@ -16,13 +16,13 @@ public class SynchronizationOnGetClassProcessorTest {
 		String pathToRepairedFile = Constants.WORKSPACE + "/spooned/" + fileName;
 
 		JavaCheckVerifier.verify(pathToBuggyFile, new SynchronizationOnGetClassCheck());
-        Main.main(new String[]{
-                "--originalFilesPath",pathToBuggyFile,
-                "--projectKey", Constants.PROJECT_KEY,
-                "--ruleKeys","3067",
-                "--workspace",Constants.WORKSPACE});
-        TestHelper.removeComplianceComments(pathToRepairedFile);
-        JavaCheckVerifier.verifyNoIssue(pathToRepairedFile, new SynchronizationOnGetClassCheck());
+		Main.main(new String[]{
+			"--originalFilesPath",pathToBuggyFile,
+			"--projectKey", Constants.PROJECT_KEY,
+			"--ruleKeys","3067",
+			"--workspace",Constants.WORKSPACE});
+		TestHelper.removeComplianceComments(pathToRepairedFile);
+		JavaCheckVerifier.verifyNoIssue(pathToRepairedFile, new SynchronizationOnGetClassCheck());
 	}
 
 }

--- a/src/test/resources/SynchronizationOnGetClass.java
+++ b/src/test/resources/SynchronizationOnGetClass.java
@@ -1,0 +1,35 @@
+class SynchronizationOnGetClass {
+  final class MemberSelect {
+    public void memberSelectOnUnknownSymbol() {
+      synchronized (this.getClass()) { // Compliant
+      }
+    }
+  }
+
+  class Coverage {
+    public void unrelatedSynchronizedExpr() {
+      Object monitor = new Object();
+      synchronized (monitor) { // Compliant
+
+      }
+    }
+  }
+
+  class InnerClass {
+    public Object getObject() {
+      Object o = new Object();
+      return o; 
+    }
+  }
+
+  public void method1() {
+    InnerClass i = new InnerClass();
+    synchronized (i.getObject().getClass()) { // Noncompliant - object's modifier is unknown, assume non-final nor enum
+    }
+  }
+
+  public void method2() {
+    synchronized (getClass()) { // Noncompliant
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a processor for the rule ["getClass" should not be used for synchronization](https://rules.sonarsource.com/java/type/Bug/RSPEC-3067)

```
class SynchronizationOnGetClass {
-  public void method1() {
-    InnerClass i = new InnerClass();
-    synchronized (i.getObject().getClass()) { // Noncompliant - object's modifier is unknown, assume non-final nor enum
-  }
+  public void method1() {
+    InnerClass i = new InnerClass();
+    synchronized(Object.class) {}
+  }
-  public void method2() {
-    synchronized (getClass()) {}
-  }
+  public void method2() {
+    synchronized(SynchronizationOnGetClass.class) {}
+  }
}
```

Regarding enum case (with modifier final), somehow sonarqube failed its own testfile due to nullpointer in their parser. The processor can handle it regardless, it just not included in our testfile.