### PR TITLE
Add UnusedThrowableProcessor (SonarSource rule 3984)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Sonarqube-repair is a collection of java code analyses and transformations made with the [Spoon](https://github.com/INRIA/spoon) library to repair violations of rules contained in [SonarQube](https://rules.sonarsource.com).
 
 ## Handled rules
-Sonarqube-repair can currently repair violations of 15 rules of which 13 are labeled as `BUG` and 2 as `Code Smell`. [Check out the handled rules](/docs/HANDLED_RULES.md).
+Sonarqube-repair can currently repair violations of 16 rules of which 14 are labeled as `BUG` and 2 as `Code Smell`. [Check out the handled rules](/docs/HANDLED_RULES.md).
 
 ## Getting started
 

--- a/docs/HANDLED_RULES.md
+++ b/docs/HANDLED_RULES.md
@@ -1,5 +1,5 @@
 ## Handled rules
-Sonarqube-repair can currently repair violations of 15 rules of which 13 are labeled as `BUG` and 2 as `Code Smell`:
+Sonarqube-repair can currently repair violations of 16 rules of which 14 are labeled as `BUG` and 2 as `Code Smell`:
 
 * [Bug](#bug)
     * [Resources should be closed](#resources-should-be-closed-sonar-rule-2095) ([Sonar Rule 2095](https://rules.sonarsource.com/java/RSPEC-2095))
@@ -15,6 +15,7 @@ Sonarqube-repair can currently repair violations of 15 rules of which 13 are lab
     * [".equals()" should not be used to test the values of "Atomic" classes](#equals-should-not-be-used-to-test-the-values-of-atomic-classes-sonar-rule-2204) ([Sonar Rule 2204](https://rules.sonarsource.com/java/RSPEC-2204))
     * ["getClass" should not be used for synchronization](#getclass-should-not-be-used-for-synchronization-sonar-rule-3067) ([Sonar Rule 3067](https://rules.sonarsource.com/java/type/Bug/RSPEC-3067))
     * [Variables should not be self-assigned](#variables-should-not-be-self-assigned-sonar-rule-1656) ([Sonar Rule 1656](https://rules.sonarsource.com/java/type/Bug/RSPEC-1656))
+    * [Exception should not be created without being thrown](#exception-should-not-be-created-without-being-thrown-sonar-rule-3984) ([Sonar Rule 3984](https://rules.sonarsource.com/java/RSPEC-3984))
 * [Code Smell](#code-smell)
     * [Unused assignments should be removed](#unused-assignments-should-be-removed-sonar-rule-1854) ([Sonar Rule 1854](https://rules.sonarsource.com/java/RSPEC-1854))
     * [Fields in a "Serializable" class should either be transient or serializable](#fields-in-a-serializable-class-should-either-be-transient-or-serializable-sonar-rule-1948) ([Sonar Rule 1948](https://rules.sonarsource.com/java/RSPEC-1948))
@@ -297,6 +298,20 @@ class SelfAssignement {
      return 0;
    }
 }
+```
+
+-----
+
+#### Exception should not be created without being thrown ([Sonar Rule 3984](https://rules.sonarsource.com/java/RSPEC-3984))
+
+Throw a `Throwable` that has been created but not thrown.
+
+Example:
+```diff
+        if (x < 0) {
+-           new IllegalArgumentException("x must be nonnegative"); // Noncompliant {{Throw this exception or remove this useless statement}}
++           throw new IllegalArgumentException("x must be nonnegative");
+        }
 ```
 
 -----

--- a/src/main/java/sonarquberepair/Processors.java
+++ b/src/main/java/sonarquberepair/Processors.java
@@ -15,6 +15,7 @@ import sonarquberepair.processor.SerializableFieldInSerializableClassProcessor;
 import sonarquberepair.processor.SynchronizationOnGetClassProcessor;
 import sonarquberepair.processor.SynchronizationOnStringOrBoxedProcessor;
 import sonarquberepair.processor.UnclosedResourcesProcessor;
+import sonarquberepair.processor.UnusedThrowableProcessor;
 import sonarquberepair.processor.SelfAssignementProcessor;
 
 import java.util.HashMap;
@@ -43,6 +44,7 @@ public class Processors {
 		TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(1860, SynchronizationOnStringOrBoxedProcessor.class);
 		TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(3067, SynchronizationOnGetClassProcessor.class);
 		TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(1656, SelfAssignementProcessor.class);
+		TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(3984, UnusedThrowableProcessor.class);
 		return TEMP_RULE_KEY_TO_PROCESSOR;
 	}
 

--- a/src/main/java/sonarquberepair/processor/UnusedThrowableProcessor.java
+++ b/src/main/java/sonarquberepair/processor/UnusedThrowableProcessor.java
@@ -1,0 +1,29 @@
+package sonarquberepair.processor;
+
+import org.sonar.java.checks.unused.UnusedThrowableCheck;
+import spoon.reflect.code.CtConstructorCall;
+import spoon.reflect.code.CtThrow;
+
+public class UnusedThrowableProcessor extends SQRAbstractProcessor<CtConstructorCall> {
+
+	public UnusedThrowableProcessor(String originalFilesPath) {
+		super(originalFilesPath, new UnusedThrowableCheck());
+	}
+
+	@Override
+	public boolean isToBeProcessed(CtConstructorCall element) {
+		if (!super.isToBeProcessedAccordingToSonar(element)) {
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public void process(CtConstructorCall element) {
+		super.process(element);
+
+		CtThrow ctThrow = getFactory().createCtThrow(element.toString());
+		element.replace(ctThrow);
+	}
+
+}

--- a/src/test/java/sonarquberepair/processor/UnusedThrowableProcessorTest.java
+++ b/src/test/java/sonarquberepair/processor/UnusedThrowableProcessorTest.java
@@ -1,0 +1,27 @@
+package sonarquberepair.processor;
+
+import org.junit.Test;
+import org.sonar.java.checks.unused.UnusedThrowableCheck;
+import org.sonar.java.checks.verifier.JavaCheckVerifier;
+import sonarquberepair.Constants;
+import sonarquberepair.Main;
+import sonarquberepair.TestHelper;
+
+public class UnusedThrowableProcessorTest {
+
+	@Test
+	public void test() throws Exception {
+		String fileName = "UnusedThrowable.java";
+		String pathToBuggyFile = Constants.PATH_TO_FILE + fileName;
+		String pathToRepairedFile = Constants.WORKSPACE + "/spooned/" + fileName;
+
+		JavaCheckVerifier.verify(pathToBuggyFile, new UnusedThrowableCheck());
+		Main.main(new String[]{
+				"--originalFilesPath",pathToBuggyFile,
+				"--ruleKeys","3984",
+				"--workspace",Constants.WORKSPACE});
+		TestHelper.removeComplianceComments(pathToRepairedFile);
+		JavaCheckVerifier.verifyNoIssue(pathToRepairedFile, new UnusedThrowableCheck());
+	}
+
+}

--- a/src/test/resources/UnusedThrowable.java
+++ b/src/test/resources/UnusedThrowable.java
@@ -1,0 +1,18 @@
+// Test for rule s3984
+// Tests from https://github.com/SonarSource/sonar-java/blob/master/java-checks/src/test/files/checks/unused/UnusedThrowableCheck.java
+
+class UnusedThrowable {
+	void foo(int x) {
+		if (x < 0) {
+			new IllegalArgumentException("x must be nonnegative"); // Noncompliant {{Throw this exception or remove this useless statement}}
+		}
+		if (x < 0) {
+			throw new IllegalArgumentException("x must be nonnegative");
+		}
+		new UnusedThrowable();
+		Throwable t = new IllegalArgumentException("x must be nonnegative");
+		if (x < 0) {
+			throw t;
+		}
+	}
+}


### PR DESCRIPTION
This PR adds a processor for the rule [Exception should not be created without being thrown](https://rules.sonarsource.com/java/RSPEC-3984).

Transformation:

```diff
 class UnusedThrowable {
 	void foo(int x) {
 		if (x < 0) {
-			new IllegalArgumentException("x must be nonnegative"); // Noncompliant {{Throw this exception or remove this useless statement}}
+			throw new IllegalArgumentException("x must be nonnegative")
+			;
 		}
 		if (x < 0) {
 			throw new IllegalArgumentException("x must be nonnegative");
 		}
 		new UnusedThrowable();
 		Throwable t = new IllegalArgumentException("x must be nonnegative");
 		if (x < 0) {
 			throw t;
 		}
 	}
}
```

Additional detail: this rule could be also handled by just removing the instantiation of the `Throwable` instead of throwing it.