### PR TITLE
Allow multiple rule keys as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ The arguments are the following:
 
   [-h|--help]
 ```
+
+Example of a concrete call to sonarqube-repair, in which multiple rule keys are given as input:
+
+```bash
+$ java -jar target/sonarqube-repair-1.1-SNAPSHOT-jar-with-dependencies.jar --originalFilesPath src/test/resources/MultipleProcessors.java --workspace /tmp/ --ruleKeys 2111,2184,2204
+```
  
 ##### If you want to run it on GitHub projects to propose PRs with fixes
 

--- a/src/main/java/sonarquberepair/DefaultRepair.java
+++ b/src/main/java/sonarquberepair/DefaultRepair.java
@@ -2,6 +2,7 @@ package sonarquberepair;
 
 import java.lang.reflect.Constructor;
 import java.io.File;
+import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
 import java.util.Map;
@@ -26,50 +27,107 @@ public class DefaultRepair {
 		}
 	}
 
-	public void repair() throws Exception {
-		File outputDir = new File(this.config.getWorkspace() + File.separator + "spooned");
+	public void repair() {
+		final String spoonedPath = this.config.getWorkspace() + File.separator + "spooned";
+		final String intermediateSpoonedPath = spoonedPath + File.separator + "intermediate";
 
+		String inputDirPath;
+		String outputDirPath;
+
+		List<Integer> ruleKeys = this.config.getRuleKeys();
+		for (int i = 0; i < ruleKeys.size(); i++) {
+			int ruleKey = ruleKeys.get(i);
+
+			if (ruleKeys.size() == 1) { // one processor, straightforward repair: we use the given input file dir, run one processor, directly output files (independently of the FileOutputStrategy) in the final output dir
+				inputDirPath = this.config.getOriginalFilesPath();
+				outputDirPath = spoonedPath;
+			} else { // more than one processor, thus we need an intermediate dir, which will always contain all files (the changed and non-changed ones), because other processors will run on them
+				if (i == 0) { // the first processor will run, thus we use the given input file dir and output *all* files in the intermediate dir
+					inputDirPath = this.config.getOriginalFilesPath();
+					outputDirPath = intermediateSpoonedPath;
+				} else if ((i + 1) == ruleKeys.size()) { // the last processor will run, thus we use as input files the ones in the intermediate dir and output files in the final output dir
+					inputDirPath = intermediateSpoonedPath;
+					outputDirPath = spoonedPath;
+				} else { // neither the first nor the last processor will run, thus use as input and output dirs the intermediate dir
+					inputDirPath = outputDirPath = intermediateSpoonedPath;
+				}
+			}
+
+			Launcher launcher = createLauncher(inputDirPath, outputDirPath);
+
+			Processor processor = createProcessor(ruleKey, inputDirPath);
+
+			Factory factory = launcher.getFactory();
+			ProcessingManager processingManager = new QueueProcessingManager(factory);
+			processingManager.addProcessor(processor);
+			JavaOutputProcessor javaOutputProcessor = launcher.createOutputWriter();
+
+			if (this.config.getFileOutputStrategy() == FileOutputStrategy.ALL
+					|| outputDirPath.contains(intermediateSpoonedPath)) {
+				processingManager.addProcessor(javaOutputProcessor);
+			}
+			processingManager.process(factory.Class().getAll());
+
+			if (this.config.getFileOutputStrategy() == FileOutputStrategy.CHANGED_ONLY
+					&& !outputDirPath.contains(intermediateSpoonedPath)) {
+				for (Map.Entry<String, CtType> patchedFile : UniqueTypesCollector.getInstance().getTopLevelTypes4Output().entrySet()) {
+					javaOutputProcessor.process(patchedFile.getValue());
+					if (this.config.getGitRepoPath() != null) {
+						createPatches(patchedFile.getKey(), javaOutputProcessor);
+					}
+				}
+			}
+		}
+
+		deleteDirectory(new File(intermediateSpoonedPath));
+
+		UniqueTypesCollector.getInstance().reset();
+	}
+
+	// FIXME: this method was copied from TestHelper.java. We should extract it to a FileHelper to be visible for both main code and test code.
+	public static boolean deleteDirectory(File directoryToBeDeleted) {
+		File[] allContents = directoryToBeDeleted.listFiles();
+		if (allContents != null) {
+			for (File file : allContents) {
+				deleteDirectory(file);
+			}
+		}
+		return directoryToBeDeleted.delete();
+	}
+
+	private Launcher createLauncher(String inputDirPath, String outputDirPath) {
 		Launcher launcher = new Launcher();
-		
-		launcher.addInputResource(this.config.getOriginalFilesPath());
-		launcher.setSourceOutputDirectory(outputDir.getAbsolutePath());
+
+		launcher.addInputResource(inputDirPath);
+		launcher.setSourceOutputDirectory(outputDirPath);
 		launcher.getEnvironment().setAutoImports(true);
 		if (this.config.getPrettyPrintingStrategy() == PrettyPrintingStrategy.SNIPER) {
 			launcher.getEnvironment().setPrettyPrinterCreator(() -> {
-				SniperJavaPrettyPrinter sniper = new SniperJavaPrettyPrinter(launcher.getEnvironment());
-				sniper.setIgnoreImplicit(false);
-				return sniper;
-			}
+						SniperJavaPrettyPrinter sniper = new SniperJavaPrettyPrinter(launcher.getEnvironment());
+						sniper.setIgnoreImplicit(false);
+						return sniper;
+					}
 			);
 			launcher.getEnvironment().setCommentEnabled(true);
 			launcher.getEnvironment().useTabulations(true);
 			launcher.getEnvironment().setTabulationSize(4);
 		}
-
-		Class<?> processor = Processors.getProcessor(config.getRuleKeys().get(0));
-		Constructor<?> cons = processor.getConstructor(String.class);
-		Object object = cons.newInstance(this.config.getOriginalFilesPath());
-
 		launcher.buildModel();
-		Factory factory = launcher.getFactory();
-		ProcessingManager processingManager = new QueueProcessingManager(factory);
-		JavaOutputProcessor javaOutputProcessor = launcher.createOutputWriter();
-		processingManager.addProcessor((Processor) object);
-		if (this.config.getFileOutputStrategy() == FileOutputStrategy.ALL) {
-			processingManager.addProcessor(javaOutputProcessor);
-		}
-		processingManager.process(factory.Class().getAll());
+		return launcher;
+	}
 
-		if (this.config.getFileOutputStrategy() == FileOutputStrategy.CHANGED_ONLY) {
-			for (Map.Entry<String, CtType> patchedFile : UniqueTypesCollector.getInstance().getTopLevelTypes4Output().entrySet()) {
-				javaOutputProcessor.process(patchedFile.getValue());
-				if (this.config.getGitRepoPath() != null) {
-					createPatches(patchedFile.getKey(), javaOutputProcessor);
-				}
+	private Processor createProcessor(Integer ruleKey, String inputDirPath) {
+		try {
+			Class<?> processor = Processors.getProcessor(ruleKey);
+			if (processor != null) {
+				Constructor<?> cons = processor.getConstructor(String.class);
+				Object object = cons.newInstance(inputDirPath);
+				return (Processor) object;
 			}
+		} catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+			e.printStackTrace();
 		}
-
-		UniqueTypesCollector.getInstance().reset();
+		return null;
 	}
 
 	private void createPatches(String patchedFilePath, JavaOutputProcessor javaOutputProcessor) {

--- a/src/main/java/sonarquberepair/Processors.java
+++ b/src/main/java/sonarquberepair/Processors.java
@@ -22,8 +22,6 @@ import sonarquberepair.processor.SelfAssignementProcessor;
 import java.util.HashMap;
 import java.util.Map;
 
-import static java.lang.System.exit;
-
 public class Processors {
 
 	private static final Map<Integer, Class<? extends SQRAbstractProcessor>> RULE_KEY_TO_PROCESSOR = init();
@@ -50,11 +48,10 @@ public class Processors {
 	}
 
 	public static Class<?> getProcessor(int ruleKey) {
-		if (!RULE_KEY_TO_PROCESSOR.containsKey(ruleKey)) {
-			System.out.println("Sorry, repair not available for rule " + ruleKey);
-			exit(0);
+		if (RULE_KEY_TO_PROCESSOR.containsKey(ruleKey)) {
+			return RULE_KEY_TO_PROCESSOR.get(ruleKey);
 		}
-		return RULE_KEY_TO_PROCESSOR.get(ruleKey);
+		return null;
 	}
 
 	public static String getRuleDescriptions() {

--- a/src/main/java/sonarquberepair/SonarQubeRepairConfig.java
+++ b/src/main/java/sonarquberepair/SonarQubeRepairConfig.java
@@ -1,11 +1,11 @@
 package sonarquberepair;
 
-import java.util.List;
 import java.util.ArrayList;
+import java.util.List;
 
 /* All config settings of SonarQube should be gathered here */
 public class SonarQubeRepairConfig {
-	private final List<Integer> ruleKeys = new ArrayList<Integer>();
+	private final List<Integer> ruleKeys = new ArrayList<>();
 	private PrettyPrintingStrategy prettyPrintingStrategy;
 	private FileOutputStrategy fileOutputStrategy;
 	private String originalFilesPath;
@@ -14,8 +14,8 @@ public class SonarQubeRepairConfig {
 
 	public SonarQubeRepairConfig() {}
 
-	public void addRuleKeys(int ruleKey) {
-		this.ruleKeys.add(ruleKey);
+	public void addRuleKeys(List<Integer> ruleKeys) {
+		this.ruleKeys.addAll(ruleKeys);
 	}
 
 	public List<Integer> getRuleKeys() {

--- a/src/test/java/sonarquberepair/FileOutputStrategyTest.java
+++ b/src/test/java/sonarquberepair/FileOutputStrategyTest.java
@@ -19,7 +19,7 @@ public class FileOutputStrategyTest {
 	public void test_onlyChangedFilesAndPatchOutput() throws Exception {
 		Main.main(new String[]{
 			"--originalFilesPath",Constants.PATH_TO_FILE,
-			"--ruleKeys","2111",
+			"--ruleKeys","4973",
 			"--fileOutputStrategy", FileOutputStrategy.CHANGED_ONLY.name(),
 			"--workspace", fileOutputStrategyTestWorkspace,
 			"--gitRepoPath","."});
@@ -35,7 +35,7 @@ public class FileOutputStrategyTest {
 	public void test_onlyChangedFilesAndNoPatchOutput() throws Exception {
 		Main.main(new String[]{
 				"--originalFilesPath",Constants.PATH_TO_FILE,
-				"--ruleKeys","2111",
+				"--ruleKeys","4973",
 				"--fileOutputStrategy", FileOutputStrategy.CHANGED_ONLY.name(),
 				"--workspace", fileOutputStrategyTestWorkspace});
 
@@ -50,7 +50,7 @@ public class FileOutputStrategyTest {
 	public void test_allFilesAndNoPatchOutput() throws Exception {
 		Main.main(new String[]{
 				"--originalFilesPath",Constants.PATH_TO_FILE,
-				"--ruleKeys","2111",
+				"--ruleKeys","4973",
 				"--fileOutputStrategy", FileOutputStrategy.ALL.name(),
 				"--workspace", fileOutputStrategyTestWorkspace});
 

--- a/src/test/java/sonarquberepair/MultipleProcessorsTest.java
+++ b/src/test/java/sonarquberepair/MultipleProcessorsTest.java
@@ -1,0 +1,28 @@
+package sonarquberepair;
+
+import org.junit.Test;
+import org.sonar.java.checks.BigDecimalDoubleConstructorCheck;
+import org.sonar.java.checks.CastArithmeticOperandCheck;
+import org.sonar.java.checks.EqualsOnAtomicClassCheck;
+import org.sonar.java.checks.verifier.JavaCheckVerifier;
+
+public class MultipleProcessorsTest {
+
+	@Test
+	public void test_threeExistingRules() throws Exception {
+		String fileName = "MultipleProcessors.java";
+		String pathToBuggyFile = Constants.PATH_TO_FILE + fileName;
+		String pathToRepairedFile = Constants.WORKSPACE + "/spooned/" + fileName;
+
+		Main.main(new String[]{
+				"--originalFilesPath",pathToBuggyFile,
+				"--ruleKeys","2111,2184,2204",
+				"--prettyPrintingStrategy","SNIPER",
+				"--workspace",Constants.WORKSPACE});
+		TestHelper.removeComplianceComments(pathToRepairedFile);
+		JavaCheckVerifier.verifyNoIssue(pathToRepairedFile, new BigDecimalDoubleConstructorCheck());
+		JavaCheckVerifier.verifyNoIssue(pathToRepairedFile, new CastArithmeticOperandCheck());
+		JavaCheckVerifier.verifyNoIssue(pathToRepairedFile, new EqualsOnAtomicClassCheck());
+	}
+
+}

--- a/src/test/resources/MultipleProcessors.java
+++ b/src/test/resources/MultipleProcessors.java
@@ -1,0 +1,17 @@
+import java.math.BigDecimal;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+class MultipleProcessors {
+
+	void foo() {
+		BigDecimal bd2 = new BigDecimal(1.1); // Noncompliant by BigDecimalDoubleConstructorCheck
+
+		float twoThirds = 2/3; // Noncompliant by CastArithmeticOperandCheck
+
+		AtomicInteger aInt1 = new AtomicInteger(0);
+		AtomicInteger aInt2 = new AtomicInteger(0);
+		isEqual = aInt1.equals(aInt2); // Noncompliant by EqualsOnAtomicClassCheck
+	}
+
+}


### PR DESCRIPTION
This PR implements the feature required in #91.

See an example of transformation by 3 different processors, all applied to the same file in a single call to sonarqube-repair:

```diff
- BigDecimal bd2 = new BigDecimal(1.1); // Noncompliant by BigDecimalDoubleConstructorCheck
+ BigDecimal bd2 = BigDecimal.valueOf(1.1); 
 
- float twoThirds = 2/3; // Noncompliant by CastArithmeticOperandCheck
+ float twoThirds = (float) 2/3; 
 
  AtomicInteger aInt1 = new AtomicInteger(0);
  AtomicInteger aInt2 = new AtomicInteger(0);
- isEqual = aInt1.equals(aInt2); // Noncompliant by EqualsOnAtomicClassCheck
+ isEqual = aInt1.get() == aInt2.get(); 
```

The general idea is to receive multiple rule keys as args and, for each rule key, to create a `Launcher` with the processor corresponding to the rule key and run it. The support of multiple rules is like that because 1) all files processed by a processor (including changed and non-changed) need to be given as input to the next processor, and 2) we have the option of outputting all files or only the changed ones (see `FileOutputStrategy`). Because of all of that combined, we need an intermediate dir when multiple processors will run, which will contain all the files (changed or not changed) after all processors, except after the last one, because then we generate files in the final output path according to the `FileOutputStrategy` chosen. I added some comments in the source code that might help to understand why some things are happening.