### PR TITLE
Use deployed sonar-java snapshot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: java
 jdk:
   - openjdk10
 
-before_install:
-  - ./init.sh
-
 script:
   - java -jar /home/travis/build/SpoonLabs/sonarqube-repair/target/sonarqube-repair-1.1-SNAPSHOT-jar-with-dependencies.jar --originalFilesPath /home/travis/build/SpoonLabs/sonarqube-repair/src/test/resources/ArrayHashCodeAndToString.java --ruleKeys 2184
   - mvn test

--- a/README.md
+++ b/README.md
@@ -17,17 +17,10 @@ A JDK (java 1.8)
 
 1) Clone this repository: `git clone https://github.com/SpoonLabs/sonarqube-repair.git`
 
-2) Run the script `./init.sh`:
-
-```bash
-$ cd sonarqube-repair
-$ chmod +x ./init.sh
-$ ./init.sh
-```
-
-3) Build and run the tool:
+2) Build and run the tool:
 
  ```bash
+$ cd sonarqube-repair
 $ mvn package -DskipTests
 $ java -jar target/sonarqube-repair-1.1-SNAPSHOT-jar-with-dependencies.jar <arguments>
  ```

--- a/init.sh
+++ b/init.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-git clone --branch modified-version https://github.com/fermadeiral/sonar-java/
-cd sonar-java/
-mvn install -DskipTests

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,6 @@
             <artifactId>spoon-core</artifactId>
             <version>8.1.0-beta-2</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.sonarsource.java/java-checks-testkit -->
         <dependency>
             <groupId>org.sonarsource.java</groupId>
             <artifactId>java-checks-testkit</artifactId>
@@ -49,10 +48,9 @@
             <artifactId>java-frontend</artifactId>
             <version>5.14.0-SNAPSHOT</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.sonarsource.java/sonar-java-plugin -->
         <dependency>
             <groupId>org.sonarsource.java</groupId>
-            <artifactId>sonar-java-plugin</artifactId>
+            <artifactId>java-checks</artifactId>
             <version>5.14.0-SNAPSHOT</version>
         </dependency>
         <dependency>
@@ -76,6 +74,11 @@
             <id>maven.inria.fr-snapshot</id>
             <name>Maven Repository for Spoon Snapshots</name>
             <url>http://maven.inria.fr/artifactory/spoon-public-snapshot</url>
+        </repository>
+        <repository>
+            <id>fermadeiral-maven-repository-snapshots</id>
+            <name>fermadeiral's Maven Repository</name>
+            <url>https://fermadeiral.github.io/maven-repository/snapshots/</url>
         </repository>
     </repositories>
     <build>


### PR DESCRIPTION
This PR is the first step for trying to handle the issue #103. Instead of using the changed version of sonar-java by building it locally with

```
git clone --branch modified-version https://github.com/fermadeiral/sonar-java/
cd sonar-java/
mvn install -DskipTests
```

the changes in this PR use a deployed snapshot from https://github.com/fermadeiral/maven-repository