### PR TITLE
Make conflicts between PRs difficult

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # Sonarqube-repair [![Travis Build Status](https://travis-ci.com/SpoonLabs/sonarqube-repair.svg?branch=master)](https://travis-ci.com/SpoonLabs/sonarqube-repair)
 
 Sonarqube-repair is a collection of java code analyses and transformations made with the [Spoon](https://github.com/INRIA/spoon) library to repair violations of rules contained in [SonarQube](https://rules.sonarsource.com).
-
-## Handled rules
-Sonarqube-repair can currently repair violations of 16 rules of which 14 are labeled as `BUG` and 2 as `Code Smell`. [Check out the handled rules](/docs/HANDLED_RULES.md).
+It can currently repair violations of [15+ rules](/docs/HANDLED_RULES.md).
 
 ## Getting started
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -26,7 +26,6 @@ So the name of your new processor is `CastArithmeticOperandCheck` replacing "Che
 
 Once you have the name for the new processor, you can create a class using that name in `src/main/java/sonarquberepair/processor`.
 This new class must extend `SQRAbstractProcessor` and implement the methods `isToBeProcessed` and `process` (check out real examples of processors [here](/src/main/java/sonarquberepair/processor)).
-After implementing your new processor, plug it in Sonarqube-repair by adding it in the code of [Processors](/src/main/java/sonarquberepair/Processors.java).
 
 3) Create a test class for the processor
 
@@ -40,10 +39,8 @@ You can find the examples provided by SonarSource in its [rules' webpage](https:
 4) Update documentation
 
 Your processor is done, it's passing the minimum tests, so now you can update the documentation.
-There are two files that you should update: [README.md](/README.md) and [HANDLED_RULES.md](/docs/HANDLED_RULES.md).
-In the `README.md` file, you should only uṕdate the number of rules handled by Sonarqube-repair.
-In the `HANDLED_RULES.md` file, you should do the same, but you should also add the new handled rule in the table of contents and a summary of its processor with an example.
-You should do it following the same way as the existing handled rules are documented. 
+In the `HANDLED_RULES.md` file, you should add the new handled rule in the table of contents, and then a summary of its processor with an example.
+You should do it following the same way as the existing handled rules are documented (note that the table of contents and summaries are alphabetically ordered).
 
 5) Open a PR
 

--- a/docs/HANDLED_RULES.md
+++ b/docs/HANDLED_RULES.md
@@ -1,47 +1,40 @@
 ## Handled rules
-Sonarqube-repair can currently repair violations of 16 rules of which 14 are labeled as `BUG` and 2 as `Code Smell`:
+Sonarqube-repair can currently repair violations of the following rules:
 
 * [Bug](#bug)
-    * [Resources should be closed](#resources-should-be-closed-sonar-rule-2095) ([Sonar Rule 2095](https://rules.sonarsource.com/java/RSPEC-2095))
-    * ["BigDecimal(double)" should not be used](#bigdecimaldouble-should-not-be-used-sonar-rule-2111) ([Sonar Rule 2111](https://rules.sonarsource.com/java/RSPEC-2111))
-    * ["hashCode" and "toString" should not be called on array instances](#hashcode-and-tostring-should-not-be-called-on-array-instances-sonar-rule-2116) ([Sonar Rule 2116](https://rules.sonarsource.com/java/RSPEC-2116))
-    * ["Iterator.next()" methods should throw "NoSuchElementException"](#iteratornext-methods-should-throw-nosuchelementexception-sonar-rule-2272) ([Sonar Rule 2272](https://rules.sonarsource.com/java/RSPEC-2272))
-    * [Strings and Boxed types should be compared using "equals()"](#strings-and-boxed-types-should-be-compared-using-equals-sonar-rule-4973) ([Sonar Rule 4973](https://rules.sonarsource.com/java/RSPEC-4973))
-    * [Math operands should be cast before assignment](#math-operands-should-be-cast-before-assignment-sonar-rule-2184) ([Sonar Rule 2184](https://rules.sonarsource.com/java/RSPEC-2184))
-    * [JEE applications should not "getClassLoader"](#jee-applications-should-not-getclassloader-sonar-rule-3032) ([Sonar Rule 3032](https://rules.sonarsource.com/java/RSPEC-3032))
-    * ["compareTo" should not return "Integer.MIN_VALUE"](#compareto-should-not-return-integermin_value-sonar-rule-2167) ([Sonar Rule 2167](https://rules.sonarsource.com/java/RSPEC-2167))
-    * [Math should not be performed on floats](#math-should-not-be-performed-on-floats-sonar-rule-2164) ([Sonar Rule 2164](https://rules.sonarsource.com/java/RSPEC-2164))
-    * [Synchronization should not be based on Strings or boxed primitives](#synchronization-should-not-be-based-on-Strings-or-boxed-primitives-sonar-rule-1860) ([Sonar Rule 1860](https://rules.sonarsource.com/java/tag/multi-threading/RSPEC-1860))
     * [".equals()" should not be used to test the values of "Atomic" classes](#equals-should-not-be-used-to-test-the-values-of-atomic-classes-sonar-rule-2204) ([Sonar Rule 2204](https://rules.sonarsource.com/java/RSPEC-2204))
+    * ["BigDecimal(double)" should not be used](#bigdecimaldouble-should-not-be-used-sonar-rule-2111) ([Sonar Rule 2111](https://rules.sonarsource.com/java/RSPEC-2111))
+    * ["Iterator.next()" methods should throw "NoSuchElementException"](#iteratornext-methods-should-throw-nosuchelementexception-sonar-rule-2272) ([Sonar Rule 2272](https://rules.sonarsource.com/java/RSPEC-2272))
+    * ["compareTo" should not return "Integer.MIN_VALUE"](#compareto-should-not-return-integermin_value-sonar-rule-2167) ([Sonar Rule 2167](https://rules.sonarsource.com/java/RSPEC-2167))
     * ["getClass" should not be used for synchronization](#getclass-should-not-be-used-for-synchronization-sonar-rule-3067) ([Sonar Rule 3067](https://rules.sonarsource.com/java/type/Bug/RSPEC-3067))
-    * [Variables should not be self-assigned](#variables-should-not-be-self-assigned-sonar-rule-1656) ([Sonar Rule 1656](https://rules.sonarsource.com/java/type/Bug/RSPEC-1656))
+    * ["hashCode" and "toString" should not be called on array instances](#hashcode-and-tostring-should-not-be-called-on-array-instances-sonar-rule-2116) ([Sonar Rule 2116](https://rules.sonarsource.com/java/RSPEC-2116))
     * [Exception should not be created without being thrown](#exception-should-not-be-created-without-being-thrown-sonar-rule-3984) ([Sonar Rule 3984](https://rules.sonarsource.com/java/RSPEC-3984))
+    * [JEE applications should not "getClassLoader"](#jee-applications-should-not-getclassloader-sonar-rule-3032) ([Sonar Rule 3032](https://rules.sonarsource.com/java/RSPEC-3032))
+    * [Math operands should be cast before assignment](#math-operands-should-be-cast-before-assignment-sonar-rule-2184) ([Sonar Rule 2184](https://rules.sonarsource.com/java/RSPEC-2184))
+    * [Math should not be performed on floats](#math-should-not-be-performed-on-floats-sonar-rule-2164) ([Sonar Rule 2164](https://rules.sonarsource.com/java/RSPEC-2164))
+    * [Resources should be closed](#resources-should-be-closed-sonar-rule-2095) ([Sonar Rule 2095](https://rules.sonarsource.com/java/RSPEC-2095))
+    * [Strings and Boxed types should be compared using "equals()"](#strings-and-boxed-types-should-be-compared-using-equals-sonar-rule-4973) ([Sonar Rule 4973](https://rules.sonarsource.com/java/RSPEC-4973))
+    * [Synchronization should not be based on Strings or boxed primitives](#synchronization-should-not-be-based-on-Strings-or-boxed-primitives-sonar-rule-1860) ([Sonar Rule 1860](https://rules.sonarsource.com/java/tag/multi-threading/RSPEC-1860))
+    * [Variables should not be self-assigned](#variables-should-not-be-self-assigned-sonar-rule-1656) ([Sonar Rule 1656](https://rules.sonarsource.com/java/type/Bug/RSPEC-1656))
 * [Code Smell](#code-smell)
-    * [Unused assignments should be removed](#unused-assignments-should-be-removed-sonar-rule-1854) ([Sonar Rule 1854](https://rules.sonarsource.com/java/RSPEC-1854))
     * [Fields in a "Serializable" class should either be transient or serializable](#fields-in-a-serializable-class-should-either-be-transient-or-serializable-sonar-rule-1948) ([Sonar Rule 1948](https://rules.sonarsource.com/java/RSPEC-1948))
+    * [Unused assignments should be removed](#unused-assignments-should-be-removed-sonar-rule-1854) ([Sonar Rule 1854](https://rules.sonarsource.com/java/RSPEC-1854))
 
 ### *Bug*
 
-#### Resources should be closed ([Sonar Rule 2095](https://rules.sonarsource.com/java/RSPEC-2095))
+#### ".equals()" should not be used to test the values of "Atomic" classes ([Sonar Rule 2204](https://rules.sonarsource.com/java/RSPEC-2204))
 
-The repair encloses the parent block of resource initialization in a try-with resources.
-If it was already in a try block it replaces the try with try-with-resources instead 
-of creating a new one, so that useless nested try blocks are not created.
+Any equality comparison between `AtomicInteger`, `AtomicLong`, or `AtomicBoolean` objects using the method `equals`, i.e., `obj1.equals(obj2)`, is replaced by a binary operator of the kind equals, where the left and right hand operands are calls to the method `.get()` using both objects.
 
 Example:
 ```diff
--            ZipInputStream zipInput = null;
--            try {
--                zipInput = new ZipInputStream(new BufferedInputStream(new FileInputStream(file)));// Noncompliant
-+            try (ZipInputStream zipInput = new ZipInputStream(new BufferedInputStream(new FileInputStream(file)))) {
-                 ZipEntry entry;
-...
-             } catch (Exception e) {
-                 Launcher.LOGGER.error(e.getMessage(), e);
-             }
+ 		AtomicInteger aInt1 = new AtomicInteger(0);
+ 		AtomicInteger aInt2 = new AtomicInteger(0);
+-		isEqual = aInt1.equals(aInt2); // Noncompliant
++		isEqual = aInt1.get() == aInt2.get();
 ```
 
-------
+-----
 
 #### "BigDecimal(double)" should not be used ([Sonar Rule 2111](https://rules.sonarsource.com/java/RSPEC-2111))
 
@@ -74,22 +67,6 @@ Check out an accepted PR in [Apache PDFBox](https://github.com/apache/pdfbox/pul
 
 -----
 
-#### "hashCode" and "toString" should not be called on array instances ([Sonar Rule 2116](https://rules.sonarsource.com/java/RSPEC-2116))
-
-Any invocation of `toString()` or `hashCode()` on an array is replaced with `Arrays.toString(parameter)` or `Arrays.hashCode(parameter)`.
-
-Example:
-```diff
--        String argStr = args.toString();// Noncompliant
--        int argHash = args.hashCode();// Noncompliant
-+        String argStr = Arrays.toString(args);
-+        int argHash = Arrays.hashCode(args);
-```
-
-Check out an accepted PR in [Spoon](https://github.com/INRIA/spoon/pull/3134) that repairs one ArrayHashCodeAndToString violation.
-
------
-
 #### "Iterator.next()" methods should throw "NoSuchElementException" ([Sonar Rule 2272](https://rules.sonarsource.com/java/RSPEC-2272))
 
 Any implementation of the `Iterator.next()` method that does not throw `NoSuchElementException` has a code snippet added to its start. The code snippet consists of a call to `hasNext()` and a throw of the error.
@@ -114,20 +91,87 @@ Check out an accepted PR in [Apache PDFBox](https://github.com/apache/pdfbox/pul
 
 -----
 
-#### Strings and Boxed types should be compared using "equals()" ([Sonar Rule 4973](https://rules.sonarsource.com/java/RSPEC-4973))
+#### "compareTo" should not return "Integer.MIN_VALUE" ([Sonar Rule 2167](https://rules.sonarsource.com/java/RSPEC-2167))
+Returning `Integer.MIN_VALUE` can cause errors because the return value of `compareTo` is sometimes inversed, with the expectation that negative values become positive. However, inversing `Integer.MIN_VALUE` yields `Integer.MIN_VALUE` rather than `Integer.MAX_VALUE`. Any `return Integer.MIN_VALUE` in a `compareTo` method is then replaced by `return -1`.
 
-Any comparison of strings or boxed types using `==` or `!=` is replaced by `equals`.
+```diff
+-  public int compareTo(CompareToReturnValue a) {
+-    return Integer.MIN_VALUE; // Noncompliant
+-  }
++  public int compareTo(CompareToReturnValue a) {
++     return -1;
++  }
+```
+
+-----
+
+#### "getClass" should not be used for synchronization ([Sonar Rule 3067](https://rules.sonarsource.com/java/RSPEC-3067))
+
+Any invocation using getClass will be typechecked if the object's invoked by `getClass` is final or an enum. If not, the invocation will be transformed to `.class` instead of `getClass`.
 
 Example:
 ```diff
--        if (firstName == lastName) // Noncompliant
-+        if (firstName.equals(lastName))
-...
--        return b != a; // Noncompliant
-+        return !b.equals(a);
+class SynchronizationOnGetClass {
+-  public void method1() {
+-    InnerClass i = new InnerClass();
+-    synchronized (i.getObject().getClass()) { // Noncompliant - object's modifier is unknown, assume non-final nor enum
+-  }
++  public void method1() {
++    InnerClass i = new InnerClass();
++    synchronized(Object.class) {}
++  }
+-  public void method2() {
+-    synchronized (getClass()) {}
+-  }
++  public void method2() {
++    synchronized(SynchronizationOnGetClass.class) {}
++  }
+}
 ```
 
-Check out an accepted PR in [Apache Sling Discovery](https://github.com/apache/sling-org-apache-sling-discovery-impl/pull/1) that repairs one CompareStringsBoxedTypesWithEquals violation.
+-----
+
+#### "hashCode" and "toString" should not be called on array instances ([Sonar Rule 2116](https://rules.sonarsource.com/java/RSPEC-2116))
+
+Any invocation of `toString()` or `hashCode()` on an array is replaced with `Arrays.toString(parameter)` or `Arrays.hashCode(parameter)`.
+
+Example:
+```diff
+-        String argStr = args.toString();// Noncompliant
+-        int argHash = args.hashCode();// Noncompliant
++        String argStr = Arrays.toString(args);
++        int argHash = Arrays.hashCode(args);
+```
+
+Check out an accepted PR in [Spoon](https://github.com/INRIA/spoon/pull/3134) that repairs one ArrayHashCodeAndToString violation.
+
+-----
+
+#### Exception should not be created without being thrown ([Sonar Rule 3984](https://rules.sonarsource.com/java/RSPEC-3984))
+
+Throw a `Throwable` that has been created but not thrown.
+
+Example:
+```diff
+        if (x < 0) {
+-           new IllegalArgumentException("x must be nonnegative"); // Noncompliant {{Throw this exception or remove this useless statement}}
++           throw new IllegalArgumentException("x must be nonnegative");
+        }
+```
+
+-----
+
+#### JEE applications should not "getClassLoader" ([Sonar Rule 3032](https://rules.sonarsource.com/java/RSPEC-3032))
+
+Using the standard `getClassLoader()` may not return the right class loader in Java Enterprise Edition context. Instead, `getClassLoader()` usage such as `this.getClass().getClassLoader()` and `Dummy.class.getClassLoader()` should be replaced by `Thread.currentThread().getContextClassLoader()`. In particular, such replacement only occurs if the `.java` file uses the `javax` package in its imports.
+
+Example:
+```diff
+-    ClassLoader d = this.getClass().getClassLoader(); // Noncompliant
++    ClassLoader d = Thread.currentThread().getContextClassLoader();
+-    Dummy.class.getClassLoader().loadClass("anotherclass"); // Noncompliant
++    Thread.currentThread().getContextClassLoader().loadClass("anotherclass");
+```
 
 -----
 
@@ -148,34 +192,6 @@ Example:
 
 -----
 
-#### JEE applications should not "getClassLoader" ([Sonar Rule 3032](https://rules.sonarsource.com/java/RSPEC-3032))
-
-Using the standard `getClassLoader()` may not return the right class loader in Java Enterprise Edition context. Instead, `getClassLoader()` usage such as `this.getClass().getClassLoader()` and `Dummy.class.getClassLoader()` should be replaced by `Thread.currentThread().getContextClassLoader()`. In particular, such replacement only occurs if the `.java` file uses the `javax` package in its imports.
-
-Example:
-```diff
--    ClassLoader d = this.getClass().getClassLoader(); // Noncompliant
-+    ClassLoader d = Thread.currentThread().getContextClassLoader();
--    Dummy.class.getClassLoader().loadClass("anotherclass"); // Noncompliant
-+    Thread.currentThread().getContextClassLoader().loadClass("anotherclass");
-```
-
------
-
-#### "compareTo" should not return "Integer.MIN_VALUE" ([Sonar Rule 2167](https://rules.sonarsource.com/java/RSPEC-2167))
-Returning `Integer.MIN_VALUE` can cause errors because the return value of `compareTo` is sometimes inversed, with the expectation that negative values become positive. However, inversing `Integer.MIN_VALUE` yields `Integer.MIN_VALUE` rather than `Integer.MAX_VALUE`. Any `return Integer.MIN_VALUE` in a `compareTo` method is then replaced by `return -1`.
-
-```diff
--  public int compareTo(CompareToReturnValue a) {
--    return Integer.MIN_VALUE; // Noncompliant
--  }
-+  public int compareTo(CompareToReturnValue a) {
-+     return -1;
-+  }
-```
-
------
-
 #### Math should not be performed on floats ([Sonar Rule 2164](https://rules.sonarsource.com/java/RSPEC-2164))
 
 In arithmetic expressions between two `float`s, both left and right operands are casted to `double`.
@@ -190,17 +206,41 @@ Example:
 
 -----
 
-#### ".equals()" should not be used to test the values of "Atomic" classes ([Sonar Rule 2204](https://rules.sonarsource.com/java/RSPEC-2204))
+#### Resources should be closed ([Sonar Rule 2095](https://rules.sonarsource.com/java/RSPEC-2095))
 
-Any equality comparison between `AtomicInteger`, `AtomicLong`, or `AtomicBoolean` objects using the method `equals`, i.e., `obj1.equals(obj2)`, is replaced by a binary operator of the kind equals, where the left and right hand operands are calls to the method `.get()` using both objects.
+The repair encloses the parent block of resource initialization in a try-with resources.
+If it was already in a try block it replaces the try with try-with-resources instead 
+of creating a new one, so that useless nested try blocks are not created.
 
 Example:
 ```diff
- 		AtomicInteger aInt1 = new AtomicInteger(0);
- 		AtomicInteger aInt2 = new AtomicInteger(0);
--		isEqual = aInt1.equals(aInt2); // Noncompliant
-+		isEqual = aInt1.get() == aInt2.get();
+-            ZipInputStream zipInput = null;
+-            try {
+-                zipInput = new ZipInputStream(new BufferedInputStream(new FileInputStream(file)));// Noncompliant
++            try (ZipInputStream zipInput = new ZipInputStream(new BufferedInputStream(new FileInputStream(file)))) {
+                 ZipEntry entry;
+...
+             } catch (Exception e) {
+                 Launcher.LOGGER.error(e.getMessage(), e);
+             }
 ```
+
+------
+
+#### Strings and Boxed types should be compared using "equals()" ([Sonar Rule 4973](https://rules.sonarsource.com/java/RSPEC-4973))
+
+Any comparison of strings or boxed types using `==` or `!=` is replaced by `equals`.
+
+Example:
+```diff
+-        if (firstName == lastName) // Noncompliant
++        if (firstName.equals(lastName))
+...
+-        return b != a; // Noncompliant
++        return !b.equals(a);
+```
+
+Check out an accepted PR in [Apache Sling Discovery](https://github.com/apache/sling-org-apache-sling-discovery-impl/pull/1) that repairs one CompareStringsBoxedTypesWithEquals violation.
 
 -----
 
@@ -232,32 +272,6 @@ Example:
 +           return this.innerLockLegal;
 +       }
   }
-```
-
------
-
-#### "getClass" should not be used for synchronization ([Sonar Rule 3067](https://rules.sonarsource.com/java/RSPEC-3067))
-
-Any invocation using getClass will be typechecked if the object's invoked by `getClass` is final or an enum. If not, the invocation will be transformed to `.class` instead of `getClass`.
-
-Example:
-```diff
-class SynchronizationOnGetClass {
--  public void method1() {
--    InnerClass i = new InnerClass();
--    synchronized (i.getObject().getClass()) { // Noncompliant - object's modifier is unknown, assume non-final nor enum
--  }
-+  public void method1() {
-+    InnerClass i = new InnerClass();
-+    synchronized(Object.class) {}
-+  }
--  public void method2() {
--    synchronized (getClass()) {}
--  }
-+  public void method2() {
-+    synchronized(SynchronizationOnGetClass.class) {}
-+  }
-}
 ```
 
 -----
@@ -302,21 +316,24 @@ class SelfAssignement {
 
 -----
 
-#### Exception should not be created without being thrown ([Sonar Rule 3984](https://rules.sonarsource.com/java/RSPEC-3984))
+### *Code Smell*
 
-Throw a `Throwable` that has been created but not thrown.
+#### Fields in a "Serializable" class should either be transient or serializable ([Sonar Rule 1948](https://rules.sonarsource.com/java/RSPEC-1948))
+
+The repair adds the modifier `transient` to all non-serializable
+fields. In the future, the plan is to give user the option if they want to go to the class
+of that field and add `implements Serializable` to it.
 
 Example:
 ```diff
-        if (x < 0) {
--           new IllegalArgumentException("x must be nonnegative"); // Noncompliant {{Throw this exception or remove this useless statement}}
-+           throw new IllegalArgumentException("x must be nonnegative");
-        }
+ public class SerializableFieldProcessorTest implements Serializable {
+-    private Unser uns;// Noncompliant
++    private transient Unser uns;
 ```
 
------
+Check out an accepted PR in [Spoon](https://github.com/INRIA/spoon/pull/2121) that repairs three SerializableFieldInSerializableClass violations.
 
-### *Code Smell*
+------
 
 #### Unused assignments should be removed ([Sonar Rule 1854](https://rules.sonarsource.com/java/RSPEC-1854))
 
@@ -338,20 +355,3 @@ Example:
 ```
 
 Check out an accepted PR in [Spoon](https://github.com/INRIA/spoon/pull/2265) that repairs one DeadStore violation.
-
-------
-
-#### Fields in a "Serializable" class should either be transient or serializable ([Sonar Rule 1948](https://rules.sonarsource.com/java/RSPEC-1948))
-
-The repair adds the modifier `transient` to all non-serializable
-fields. In the future, the plan is to give user the option if they want to go to the class
-of that field and add `implements Serializable` to it.
-
-Example:
-```diff
- public class SerializableFieldProcessorTest implements Serializable {
--    private Unser uns;// Noncompliant
-+    private transient Unser uns;
-```
-
-Check out an accepted PR in [Spoon](https://github.com/INRIA/spoon/pull/2121) that repairs three SerializableFieldInSerializableClass violations.

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,11 @@
             <artifactId>org.eclipse.jgit</artifactId>
             <version>5.7.0.202003110725-r</version>
         </dependency>
+        <dependency>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
+            <version>0.9.12</version>
+        </dependency>
     </dependencies>
     <properties>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/src/main/java/sonarquberepair/ProcessorAnnotation.java
+++ b/src/main/java/sonarquberepair/ProcessorAnnotation.java
@@ -8,5 +8,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface ProcessorAnnotation {
+	public int key();
 	public String description();
 }

--- a/src/main/java/sonarquberepair/Processors.java
+++ b/src/main/java/sonarquberepair/Processors.java
@@ -1,23 +1,9 @@
 package sonarquberepair;
 
 import java.lang.annotation.Annotation;
-import sonarquberepair.processor.ArrayHashCodeAndToStringProcessor;
-import sonarquberepair.processor.BigDecimalDoubleConstructorProcessor;
-import sonarquberepair.processor.CastArithmeticOperandProcessor;
-import sonarquberepair.processor.CompareStringsBoxedTypesWithEqualsProcessor;
-import sonarquberepair.processor.CompareToReturnValueProcessor;
-import sonarquberepair.processor.DeadStoreProcessor;
-import sonarquberepair.processor.EqualsOnAtomicClassProcessor;
-import sonarquberepair.processor.GetClassLoaderProcessor;
-import sonarquberepair.processor.IteratorNextExceptionProcessor;
-import sonarquberepair.processor.MathOnFloatProcessor;
+import java.util.Set;
+import org.reflections.Reflections;
 import sonarquberepair.processor.SQRAbstractProcessor;
-import sonarquberepair.processor.SerializableFieldInSerializableClassProcessor;
-import sonarquberepair.processor.SynchronizationOnGetClassProcessor;
-import sonarquberepair.processor.SynchronizationOnStringOrBoxedProcessor;
-import sonarquberepair.processor.UnclosedResourcesProcessor;
-import sonarquberepair.processor.UnusedThrowableProcessor;
-import sonarquberepair.processor.SelfAssignementProcessor;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -30,22 +16,17 @@ public class Processors {
 
 	private static Map init() {
 		Map<Integer, Class<? extends SQRAbstractProcessor>> TEMP_RULE_KEY_TO_PROCESSOR = new HashMap<>();
-		TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(1854, DeadStoreProcessor.class);
-		TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(1948, SerializableFieldInSerializableClassProcessor.class);
-		TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(2095, UnclosedResourcesProcessor.class);
-		TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(2111, BigDecimalDoubleConstructorProcessor.class);
-		TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(2116, ArrayHashCodeAndToStringProcessor.class);
-		TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(2272, IteratorNextExceptionProcessor.class);
-		TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(4973, CompareStringsBoxedTypesWithEqualsProcessor.class);
-		TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(2184, CastArithmeticOperandProcessor.class);
-		TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(3032, GetClassLoaderProcessor.class);
-		TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(2167, CompareToReturnValueProcessor.class);
-		TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(2164, MathOnFloatProcessor.class);
-		TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(2204, EqualsOnAtomicClassProcessor.class);
-		TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(1860, SynchronizationOnStringOrBoxedProcessor.class);
-		TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(3067, SynchronizationOnGetClassProcessor.class);
-		TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(1656, SelfAssignementProcessor.class);
-		TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(3984, UnusedThrowableProcessor.class);
+		Reflections reflections = new Reflections("sonarquberepair.processor");
+		Set<Class<? extends SQRAbstractProcessor>> allProcessors = reflections.getSubTypesOf(SQRAbstractProcessor.class);
+		for (Class<? extends SQRAbstractProcessor> processor : allProcessors) {
+			Annotation[] annotations = processor.getAnnotations();
+			for (Annotation annotation : annotations) {
+				if (annotation instanceof ProcessorAnnotation) {
+					ProcessorAnnotation myAnnotation = (ProcessorAnnotation) annotation;
+					TEMP_RULE_KEY_TO_PROCESSOR.putIfAbsent(myAnnotation.key(), processor);
+				}
+			}
+		}
 		return TEMP_RULE_KEY_TO_PROCESSOR;
 	}
 

--- a/src/main/java/sonarquberepair/processor/ArrayHashCodeAndToStringProcessor.java
+++ b/src/main/java/sonarquberepair/processor/ArrayHashCodeAndToStringProcessor.java
@@ -11,7 +11,7 @@ import spoon.reflect.reference.CtExecutableReference;
 
 import java.util.Arrays;
 
-@ProcessorAnnotation(description="\"hashCode\" and \"toString\" should not be called on array instances")
+@ProcessorAnnotation(key = 2116, description = "\"hashCode\" and \"toString\" should not be called on array instances")
 public class ArrayHashCodeAndToStringProcessor extends SQRAbstractProcessor<CtInvocation<?>> {
 
 	final String TOSTRING = "toString";

--- a/src/main/java/sonarquberepair/processor/BigDecimalDoubleConstructorProcessor.java
+++ b/src/main/java/sonarquberepair/processor/BigDecimalDoubleConstructorProcessor.java
@@ -11,7 +11,7 @@ import spoon.reflect.reference.CtTypeReference;
 import java.math.BigDecimal;
 import java.util.List;
 
-@ProcessorAnnotation(description="\"BigDecimal(double)\" should not be used")
+@ProcessorAnnotation(key = 2111, description = "\"BigDecimal(double)\" should not be used")
 public class BigDecimalDoubleConstructorProcessor extends SQRAbstractProcessor<CtConstructorCall> {
 
 	public BigDecimalDoubleConstructorProcessor(String originalFilesPath) {

--- a/src/main/java/sonarquberepair/processor/CastArithmeticOperandProcessor.java
+++ b/src/main/java/sonarquberepair/processor/CastArithmeticOperandProcessor.java
@@ -12,7 +12,7 @@ import spoon.reflect.visitor.filter.TypeFilter;
 
 import java.util.List;
 
-@ProcessorAnnotation(description="Math operands should be cast before assignment")
+@ProcessorAnnotation(key = 2184, description = "Math operands should be cast before assignment")
 public class CastArithmeticOperandProcessor extends SQRAbstractProcessor<CtBinaryOperator> {
 
     private CtTypeReference typeToBeUsedToCast;

--- a/src/main/java/sonarquberepair/processor/CompareStringsBoxedTypesWithEqualsProcessor.java
+++ b/src/main/java/sonarquberepair/processor/CompareStringsBoxedTypesWithEqualsProcessor.java
@@ -9,7 +9,7 @@ import spoon.reflect.code.BinaryOperatorKind;
 import spoon.reflect.code.CtBinaryOperator;
 import spoon.reflect.reference.CtTypeReference;
 
-@ProcessorAnnotation(description="Strings and Boxed types should be compared using \"equals()\"")
+@ProcessorAnnotation(key = 4973, description = "Strings and Boxed types should be compared using \"equals()\"")
 public class CompareStringsBoxedTypesWithEqualsProcessor extends SQRAbstractProcessor<CtElement> {
 
 	public CompareStringsBoxedTypesWithEqualsProcessor(String originalFilesPath) {

--- a/src/main/java/sonarquberepair/processor/CompareToReturnValueProcessor.java
+++ b/src/main/java/sonarquberepair/processor/CompareToReturnValueProcessor.java
@@ -6,7 +6,7 @@ import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.code.CtReturn;
 import spoon.reflect.code.CtLiteral;
 
-@ProcessorAnnotation(description="\"compareTo\" should not return \"Integer.MIN_VALUE\"")
+@ProcessorAnnotation(key = 2167, description = "\"compareTo\" should not return \"Integer.MIN_VALUE\"")
 public class CompareToReturnValueProcessor extends SQRAbstractProcessor<CtReturn<?>> {
 
 	public CompareToReturnValueProcessor(String originalFilesPath) {

--- a/src/main/java/sonarquberepair/processor/DeadStoreProcessor.java
+++ b/src/main/java/sonarquberepair/processor/DeadStoreProcessor.java
@@ -6,7 +6,7 @@ import spoon.reflect.code.CtAssignment;
 import spoon.reflect.code.CtLocalVariable;
 import spoon.reflect.code.CtStatement;
 
-@ProcessorAnnotation(description="Unused assignments should be removed")
+@ProcessorAnnotation(key = 1854, description = "Unused assignments should be removed")
 public class DeadStoreProcessor extends SQRAbstractProcessor<CtStatement> {
 
 	public DeadStoreProcessor(String originalFilesPath) {

--- a/src/main/java/sonarquberepair/processor/EqualsOnAtomicClassProcessor.java
+++ b/src/main/java/sonarquberepair/processor/EqualsOnAtomicClassProcessor.java
@@ -13,7 +13,7 @@ import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.reference.CtExecutableReference;
 
-@ProcessorAnnotation(description="\".equals()\" should not be used to test the values of \"Atomic\" classes")
+@ProcessorAnnotation(key = 2204, description = "\".equals()\" should not be used to test the values of \"Atomic\" classes")
 public class EqualsOnAtomicClassProcessor extends SQRAbstractProcessor<CtInvocation> {
 
 	public EqualsOnAtomicClassProcessor(String originalFilesPath) {

--- a/src/main/java/sonarquberepair/processor/GetClassLoaderProcessor.java
+++ b/src/main/java/sonarquberepair/processor/GetClassLoaderProcessor.java
@@ -14,7 +14,7 @@ import spoon.reflect.declaration.CtImport;
 
 import java.util.HashMap;
 
-@ProcessorAnnotation(description="JEE applications should not \"getClassLoader\"")
+@ProcessorAnnotation(key = 3032, description = "JEE applications should not \"getClassLoader\"")
 public class GetClassLoaderProcessor extends SQRAbstractProcessor<CtInvocation<?>> {
 	private HashMap<Integer,Boolean> hashCodesOfTypesUsingJEE = new HashMap<Integer,Boolean>();
 

--- a/src/main/java/sonarquberepair/processor/IteratorNextExceptionProcessor.java
+++ b/src/main/java/sonarquberepair/processor/IteratorNextExceptionProcessor.java
@@ -15,7 +15,7 @@ import spoon.reflect.reference.CtTypeReference;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
-@ProcessorAnnotation(description="\"Iterator.next()\" methods should throw \"NoSuchElementException\"")
+@ProcessorAnnotation(key = 2272, description = "\"Iterator.next()\" methods should throw \"NoSuchElementException\"")
 public class IteratorNextExceptionProcessor extends SQRAbstractProcessor<CtMethod> {
 
 	public IteratorNextExceptionProcessor(String originalFilesPath) {

--- a/src/main/java/sonarquberepair/processor/MathOnFloatProcessor.java
+++ b/src/main/java/sonarquberepair/processor/MathOnFloatProcessor.java
@@ -10,7 +10,7 @@ import spoon.reflect.visitor.filter.TypeFilter;
 
 import java.util.List;
 
-@ProcessorAnnotation(description="Math should not be performed on floats")
+@ProcessorAnnotation(key = 2164, description = "Math should not be performed on floats")
 public class MathOnFloatProcessor extends SQRAbstractProcessor<CtBinaryOperator> {
 
     public MathOnFloatProcessor(String originalFilesPath) {

--- a/src/main/java/sonarquberepair/processor/SelfAssignementProcessor.java
+++ b/src/main/java/sonarquberepair/processor/SelfAssignementProcessor.java
@@ -16,7 +16,7 @@ import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtVariable;
 import spoon.reflect.declaration.CtType;
 
-@ProcessorAnnotation(description="Variables should not be self-assigned")
+@ProcessorAnnotation(key = 1656, description = "Variables should not be self-assigned")
 public class SelfAssignementProcessor extends SQRAbstractProcessor<CtAssignment<?,?>> {
 
 	public SelfAssignementProcessor(String originalFilesPath) {

--- a/src/main/java/sonarquberepair/processor/SerializableFieldInSerializableClassProcessor.java
+++ b/src/main/java/sonarquberepair/processor/SerializableFieldInSerializableClassProcessor.java
@@ -5,7 +5,7 @@ import sonarquberepair.ProcessorAnnotation;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.ModifierKind;
 
-@ProcessorAnnotation(description="Fields in a \"Serializable\" class should either be transient or serializable")
+@ProcessorAnnotation(key = 1948, description = "Fields in a \"Serializable\" class should either be transient or serializable")
 public class SerializableFieldInSerializableClassProcessor extends SQRAbstractProcessor<CtField> {
 
 	public SerializableFieldInSerializableClassProcessor(String originalFilesPath) {

--- a/src/main/java/sonarquberepair/processor/SynchronizationOnGetClassProcessor.java
+++ b/src/main/java/sonarquberepair/processor/SynchronizationOnGetClassProcessor.java
@@ -13,7 +13,7 @@ import spoon.reflect.reference.CtTypeReference;
 
 import java.util.Set;
 
-@ProcessorAnnotation(description="\"getClass\" should not be used for synchronization")
+@ProcessorAnnotation(key = 3067, description = "\"getClass\" should not be used for synchronization")
 public class SynchronizationOnGetClassProcessor extends SQRAbstractProcessor<CtSynchronized> {
 
 	public SynchronizationOnGetClassProcessor(String originalFilesPath) {

--- a/src/main/java/sonarquberepair/processor/SynchronizationOnStringOrBoxedProcessor.java
+++ b/src/main/java/sonarquberepair/processor/SynchronizationOnStringOrBoxedProcessor.java
@@ -21,7 +21,7 @@ import spoon.reflect.declaration.CtMethod;
 import java.util.HashMap;
 import java.util.Map;
 
-@ProcessorAnnotation(description="Synchronization should not be based on Strings or boxed primitives")
+@ProcessorAnnotation(key = 1860, description = "Synchronization should not be based on Strings or boxed primitives")
 public class SynchronizationOnStringOrBoxedProcessor extends SQRAbstractProcessor<CtSynchronized> {
     private Map<Integer,CtVariableReference> old2NewFields;
     private Map<Integer,CtExecutableReference> old2NewMethods;

--- a/src/main/java/sonarquberepair/processor/UnclosedResourcesProcessor.java
+++ b/src/main/java/sonarquberepair/processor/UnclosedResourcesProcessor.java
@@ -15,7 +15,7 @@ import spoon.reflect.declaration.CtElement;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtVariableReference;
 
-@ProcessorAnnotation(description="Resources should be closed")
+@ProcessorAnnotation(key = 2095, description = "Resources should be closed")
 public class UnclosedResourcesProcessor extends SQRAbstractProcessor<CtConstructorCall> {
 
 	public UnclosedResourcesProcessor(String originalFilesPath) {

--- a/src/main/java/sonarquberepair/processor/UnusedThrowableProcessor.java
+++ b/src/main/java/sonarquberepair/processor/UnusedThrowableProcessor.java
@@ -5,7 +5,7 @@ import sonarquberepair.ProcessorAnnotation;
 import spoon.reflect.code.CtConstructorCall;
 import spoon.reflect.code.CtThrow;
 
-@ProcessorAnnotation(description="Exception should not be created without being thrown")
+@ProcessorAnnotation(key = 3984, description = "Exception should not be created without being thrown")
 public class UnusedThrowableProcessor extends SQRAbstractProcessor<CtConstructorCall> {
 
 	public UnusedThrowableProcessor(String originalFilesPath) {


### PR DESCRIPTION
When we create new-processor pull-requests, let's say 2, and one is merged, the open one will get conflicts with the master.

Each new-processor pull-request contains change in exactly 6 files:
- A processor class (an added file, thus it's fine)
- A test class for the processor class (an added file, thus it's fine)
- A resource test file (an added file, thus it's fine)
- A change in `Processors` (conflict)
- A change in `README.md` (conflict)
- 3 changes in `HANDLED_RULES.md` (conflict)

So an open new-processor pull-request will have conflict in 3 files when another new-processor pull-request is merged.

This PR introduces changes that will eliminate conflicts with two files, and will minimize the chances of conflict in the third file.

@henry-lp, you have faced this situation, thus I would like to know your opinion about this PR :)