### PR TITLE
Feat: skip duplicated types during spoon model building

### DIFF
--- a/src/main/java/sonarquberepair/DefaultRepair.java
+++ b/src/main/java/sonarquberepair/DefaultRepair.java
@@ -101,6 +101,7 @@ public class DefaultRepair {
 		launcher.addInputResource(inputDirPath);
 		launcher.setSourceOutputDirectory(outputDirPath);
 		launcher.getEnvironment().setAutoImports(true);
+		launcher.getEnvironment().setIgnoreDuplicateDeclarations(true);
 		if (this.config.getPrettyPrintingStrategy() == PrettyPrintingStrategy.SNIPER) {
 			launcher.getEnvironment().setPrettyPrinterCreator(() -> {
 						SniperJavaPrettyPrinter sniper = new SniperJavaPrettyPrinter(launcher.getEnvironment());


### PR DESCRIPTION
A project might have sub projects or files in some resources folder containing classes of the same name as another class in another location. This PR suggests that we ignore loading the same type twice by one-by-one loading in each files into `SpoonLauncher` while skipping the type already occured to improve usability for the CI integration by avoiding `spoon.compiler.ModelBuildingException`. :)

what this PR does:
* Move all buggy files into a new folder in the resources folder
* create a new folder for duplicated files in the resources folder
* Add one-by-one loading logic into `SpoonLauncher`
* Add JSAP option to activate that.

@monperrus @fermadeiral 